### PR TITLE
Fix rubocop links to point to the right version.

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
@@ -30,11 +30,11 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
     "refactor"   => "Refac",
   }.freeze
 
-  COP_DOCUMENTATION_URI = "http://rubydoc.info/gems/rubocop/frames"
+  COP_DOCUMENTATION_URI = File.join("http://rubydoc.info/gems/rubocop", Rubocop::Version.version)
   COP_URIS =
     Rubocop::Cop::Cop.subclasses.each_with_object({}) do |cop, h|
       cop_name = cop.name.split("::").last
-      cop_uri  = File.join(COP_DOCUMENTATION_URI, cop.name.gsub("::", "/"))
+      cop_uri  = File.join(COP_DOCUMENTATION_URI, cop.name.split("::"))
       h[cop_name] = "[#{cop_name}](#{cop_uri})"
     end.freeze
 

--- a/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
@@ -33,14 +33,14 @@ Checked commits https://github.com/some_user/some_repo/commit/1ec36efd33279f79f8
 4 files checked, 4 offenses detected
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb**
-- [ ] Style - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb#L3), Col 5 - [AlignHash](http://rubydoc.info/gems/rubocop/frames/Rubocop/Cop/Style/AlignHash) - Align the elements of a hash literal if they span more than one line.
-- [ ] Style - [Line 4](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb#L4), Col 5 - [AlignHash](http://rubydoc.info/gems/rubocop/frames/Rubocop/Cop/Style/AlignHash) - Align the elements of a hash literal if they span more than one line.
+- [ ] Style - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb#L3), Col 5 - [AlignHash](http://rubydoc.info/gems/rubocop/#{rubocop_version}/Rubocop/Cop/Style/AlignHash) - Align the elements of a hash literal if they span more than one line.
+- [ ] Style - [Line 4](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb#L4), Col 5 - [AlignHash](http://rubydoc.info/gems/rubocop/#{rubocop_version}/Rubocop/Cop/Style/AlignHash) - Align the elements of a hash literal if they span more than one line.
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_syntax_error.rb**
 - [ ] Error - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_syntax_error.rb#L3), Col 1 - Syntax - unexpected token kEND
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_warning.rb**
-- [ ] Warn - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_warning.rb#L3), Col 5 - [UselessAssignment](http://rubydoc.info/gems/rubocop/frames/Rubocop/Cop/Lint/UselessAssignment) - Useless assignment to variable - `unused_variable`.
+- [ ] Warn - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_warning.rb#L3), Col 5 - [UselessAssignment](http://rubydoc.info/gems/rubocop/#{rubocop_version}/Rubocop/Cop/Lint/UselessAssignment) - Useless assignment to variable - `unused_variable`.
       EOMSG
     end
 


### PR DESCRIPTION
Fixes #2 

@jrafanie or @brandondunne Please review.

Example URL:
old: http://rubydoc.info/gems/rubocop/frames/Rubocop/Cop/Style/AlignHash
new: http://rubydoc.info/gems/rubocop/0.21.0/Rubocop/Cop/Style/AlignHash
