### PR TITLE
Added invisible HTML tags to github comments for easy detection.

### DIFF
--- a/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
+++ b/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
@@ -25,6 +25,10 @@ class CommitMonitorHandlers::Branch::PrMergeabilityChecker
 
   private
 
+  def tag
+    "<pr_mergeability_checker />"
+  end
+
   def process_mergeability
     was_mergeable = branch.mergeable?
     currently_mergeable = branch.repo.with_git_service do |git|
@@ -43,7 +47,7 @@ class CommitMonitorHandlers::Branch::PrMergeabilityChecker
     branch.repo.with_github_service do |github|
       github.issues.comments.create(
         :issue_id => branch.pr_number,
-        :body     => "This pull request is not mergeable.  Please rebase and repush."
+        :body     => "#{tag}This pull request is not mergeable.  Please rebase and repush."
       )
     end
   end

--- a/app/workers/commit_monitor_handlers/commit/gemfile_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit/gemfile_checker.rb
@@ -28,6 +28,10 @@ class CommitMonitorHandlers::Commit::GemfileChecker
 
   private
 
+  def tag
+    "<gemfile_checker />"
+  end
+
   def process_branch
     send("process_#{branch.pull_request? ? "pr" : "regular"}_branch")
   end
@@ -38,7 +42,7 @@ class CommitMonitorHandlers::Commit::GemfileChecker
     branch.repo.with_github_service do |github|
       github.issues.comments.create(
         :issue_id => branch.pr_number,
-        :body     => "#{Settings.gemfile_checker.pr_contacts.join(" ")} Gemfile changes detected in commit #{branch.commit_uri_to(commit)}.  Please review."
+        :body     => "#{tag}#{Settings.gemfile_checker.pr_contacts.join(" ")} Gemfile changes detected in commit #{branch.commit_uri_to(commit)}.  Please review."
       )
     end
   end

--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -108,7 +108,6 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
   end
 
   def rubocop_comment?(comment)
-    first_line = comment.body.split("\n").first.to_s
-    first_line =~ /^Checked commit.+with rubocop/ || first_line.include?("...continued")
+    comment.body.start_with?("<rubocop />")
   end
 end

--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
@@ -39,6 +39,10 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
       h[cop_name] = "[#{cop_name}](#{cop_uri})"
     end.freeze
 
+  def tag
+    "<rubocop />"
+  end
+
   def build_messages
     write_header
     files.empty? ? write_success : write_offenses
@@ -60,7 +64,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
       branch.commit_uri_to(commits.first),
       branch.commit_uri_to(commits.last),
     ].uniq.join(" .. ")
-    write("Checked #{"commit".pluralize(commits.length)} #{commit_range} with rubocop #{rubocop_version}")
+    write("#{tag}Checked #{"commit".pluralize(commits.length)} #{commit_range} with rubocop #{rubocop_version}")
 
     file_count    = results.fetch_path("summary", "target_file_count").to_i
     offense_count = results.fetch_path("summary", "offense_count").to_i
@@ -68,7 +72,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
   end
 
   def write_header_continued
-    write("**...continued**\n")
+    write("#{tag}**...continued**\n")
   end
 
   def write_success

--- a/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
@@ -18,7 +18,7 @@ describe CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder do
     it "with results with offenses" do
       expect(subject.length).to eq 1
       expect(subject.first).to  eq <<-EOMSG
-Checked commits https://github.com/some_user/some_repo/commit/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6 .. https://github.com/some_user/some_repo/commit/8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/commit/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6 .. https://github.com/some_user/some_repo/commit/8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version}
 4 files checked, 4 offenses detected
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb**
@@ -36,7 +36,7 @@ Checked commits https://github.com/some_user/some_repo/commit/1ec36efd33279f79f8
     it "with results with no offenses" do
       expect(subject.length).to eq 1
       expect(subject.first).to  start_with <<-EOMSG.chomp
-Checked commits https://github.com/some_user/some_repo/commit/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6 .. https://github.com/some_user/some_repo/commit/8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/commit/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6 .. https://github.com/some_user/some_repo/commit/8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version}
 1 file checked, 0 offenses detected
 Everything looks good.
       EOMSG
@@ -46,10 +46,10 @@ Everything looks good.
     it "with multiple messages" do
       expect(subject.length).to eq 2
       expect(subject.first).to  start_with <<-EOMSG.chomp
-Checked commits https://github.com/some_user/some_repo/commit/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6 .. https://github.com/some_user/some_repo/commit/8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/commit/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6 .. https://github.com/some_user/some_repo/commit/8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version}
 1 file checked, 194 offenses detected
       EOMSG
-      expect(subject.last).to   start_with "**...continued**\n"
+      expect(subject.last).to   start_with "<rubocop />**...continued**\n"
     end
   end
 end


### PR DESCRIPTION
Eventually I want to extract the github message builder class, but for now I just added in the tags themselves.  This makes it easier to find old commits for cleanup and deletion.  These tags are not visible in the UI (as you can see here: <wow_invisible />)