### PR TITLE
Changed rubocop prefix to use colored emoji for readability

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
@@ -23,11 +23,11 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
   SUCCESS_EMOJI = %w{:+1: :cookie: :star: :cake:}
 
   SEVERITY = {
-    "fatal"      => "**Fatal**",
-    "error"      => "**Error**",
-    "warning"    => "**Warn**",
-    "convention" => "Style",
-    "refactor"   => "Refac",
+    "fatal"      => ":red_circle: **Fatal**",
+    "error"      => ":red_circle: **Error**",
+    "warning"    => ":red_circle: **Warn**",
+    "convention" => ":large_orange_diamond:",
+    "refactor"   => ":small_blue_diamond:",
   }.freeze
 
   COP_DOCUMENTATION_URI = File.join("http://rubydoc.info/gems/rubocop", RuboCop::Version.version)
@@ -46,7 +46,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
   def build_messages
     write_header
     files.empty? ? write_success : write_offenses
-    @messages.collect! { |m| m.string }
+    @messages.collect!(&:string)
   end
 
   def write(line)

--- a/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
@@ -22,14 +22,14 @@ describe CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder do
 4 files checked, 4 offenses detected
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb**
-- [ ] Style - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb#L3), Col 5 - [Style/AlignHash](http://rubydoc.info/gems/rubocop/#{rubocop_version}/RuboCop/Cop/Style/AlignHash) - Align the elements of a hash literal if they span more than one line.
-- [ ] Style - [Line 4](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb#L4), Col 5 - [Style/AlignHash](http://rubydoc.info/gems/rubocop/#{rubocop_version}/RuboCop/Cop/Style/AlignHash) - Align the elements of a hash literal if they span more than one line.
+- [ ] :large_orange_diamond: - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb#L3), Col 5 - [Style/AlignHash](http://rubydoc.info/gems/rubocop/#{rubocop_version}/RuboCop/Cop/Style/AlignHash) - Align the elements of a hash literal if they span more than one line.
+- [ ] :large_orange_diamond: - [Line 4](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb#L4), Col 5 - [Style/AlignHash](http://rubydoc.info/gems/rubocop/#{rubocop_version}/RuboCop/Cop/Style/AlignHash) - Align the elements of a hash literal if they span more than one line.
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_syntax_error.rb**
-- [ ] **Error** - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_syntax_error.rb#L3), Col 1 - Syntax - unexpected token kEND
+- [ ] :red_circle: **Error** - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_syntax_error.rb#L3), Col 1 - Syntax - unexpected token kEND
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_warning.rb**
-- [ ] **Warn** - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_warning.rb#L3), Col 5 - [Lint/UselessAssignment](http://rubydoc.info/gems/rubocop/#{rubocop_version}/RuboCop/Cop/Lint/UselessAssignment) - Useless assignment to variable - `unused_variable`.
+- [ ] :red_circle: **Warn** - [Line 3](https://github.com/some_user/some_repo/blob/8942a195a0bfa69ceb82c020c60565408cb46d3e/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/ruby_warning.rb#L3), Col 5 - [Lint/UselessAssignment](http://rubydoc.info/gems/rubocop/#{rubocop_version}/RuboCop/Cop/Lint/UselessAssignment) - Useless assignment to variable - `unused_variable`.
       EOMSG
     end
 


### PR DESCRIPTION
Goes with ManageIQ/manageiq#1657 and ManageIQ/guides#54
Issue #9

Example (hand edited from a PR on ManageIQ/manageiq):

---

Checked commit https://github.com/h-kataria/manageiq/commit/01e3b442bf39c0f9c0c2c907812d7f27e9a2db01 with rubocop 0.27.1
1 file checked, 5 offenses detected

**vmdb/app/helpers/application_helper.rb**
- [x] :red_circle: **Warn** - [Line 2611](https://github.com/h-kataria/manageiq/blob/01e3b442bf39c0f9c0c2c907812d7f27e9a2db01/vmdb/app/helpers/application_helper.rb#L2611), Col 11 - [Lint/LiteralInCondition](http://rubydoc.info/gems/rubocop/0.27.1/RuboCop/Cop/Lint/LiteralInCondition) - Literal `%w(action availability_zone cim_base_storage_extent cloud_tenant condition ems_cloud ems_cluster
             ems_infra flavor host miq_proxy miq_schedule miq_template policy ontap_file_share ontap_logical_disk
             ontap_storage_system ontap_storage_volume orchestration_stack repository resource_pool scan_profile
             security_group service snia_local_file_system storage storage_manager timeline)` appeared in a condition.
- [x] :large_orange_diamond: - [Line 2604](https://github.com/h-kataria/manageiq/blob/01e3b442bf39c0f9c0c2c907812d7f27e9a2db01/vmdb/app/helpers/application_helper.rb#L2604), Col 7 - [Style/MultilineOperationIndentation](http://rubydoc.info/gems/rubocop/0.27.1/RuboCop/Cop/Style/MultilineOperationIndentation) - Align the operands of a condition in an `if` statement spanning multiple lines.
- [x] :large_orange_diamond: - [Line 2620](https://github.com/h-kataria/manageiq/blob/01e3b442bf39c0f9c0c2c907812d7f27e9a2db01/vmdb/app/helpers/application_helper.rb#L2620), Col 1 - [Style/EmptyLinesAroundModuleBody](http://rubydoc.info/gems/rubocop/0.27.1/RuboCop/Cop/Style/EmptyLinesAroundModuleBody) - Extra empty line detected at module body end.
- [x] :small_blue_diamond: - [Line 2602](https://github.com/h-kataria/manageiq/blob/01e3b442bf39c0f9c0c2c907812d7f27e9a2db01/vmdb/app/helpers/application_helper.rb#L2602), Col 3 - [Metrics/CyclomaticComplexity](http://rubydoc.info/gems/rubocop/0.27.1/RuboCop/Cop/Metrics/CyclomaticComplexity) - Cyclomatic complexity for render_listnav_filename is too high. [8/6]
- [x] :small_blue_diamond: - [Line 2602](https://github.com/h-kataria/manageiq/blob/01e3b442bf39c0f9c0c2c907812d7f27e9a2db01/vmdb/app/helpers/application_helper.rb#L2602), Col 3 - [Metrics/PerceivedComplexity](http://rubydoc.info/gems/rubocop/0.27.1/RuboCop/Cop/Metrics/PerceivedComplexity) - Perceived complexity for render_listnav_filename is too high. [9/7]