### PR TITLE
Enhance gemfile checker

### DIFF
--- a/app/workers/commit_monitor_handlers/commit/gemfile_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit/gemfile_checker.rb
@@ -15,8 +15,10 @@ class CommitMonitorHandlers::Commit::GemfileChecker
       logger.info("Branch #{branch_id} no longer exists.  Skipping.")
       return
     end
-    if @branch.repo.fq_name != "ManageIQ/manageiq"
-      logger.info("#{self.class} only runs on ManageIQ/manageiq, not #{@branch.repo.fq_name}.  Skipping.")
+
+    enabled_repos = Settings.gemfile_checker.enabled_repos
+    unless @branch.repo.fq_name.in?(enabled_repos)
+      logger.info("#{self.class} only runs in #{enabled_repos}, not #{@branch.repo.fq_name}.  Skipping.")
       return
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,5 +9,6 @@ commit_monitor:
   bugzilla_product:
 gemfile_checker:
   pr_contacts: []
+  enabled_repos: []
 issue_manager:
   repo_names: []


### PR DESCRIPTION
* Configure the repository that GemfileChecker monitors.
  * This makes it easier to test "ManageIQ/sandbox" as an example.
* Delete prior Gemfile comments before adding a new one.
* Add the "gem changes" label to the PR if it's not already applied.
  * Fixes #3

cc @Fryguy 

Once this in, we can extract much of the code that is similar to the rubucop checker that detects the already existing comments.