### PR TITLE
Add labels subscription

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,3 +11,5 @@ gemfile_checker:
   pr_contacts: []
 issue_manager:
   repo_names: []
+label_notifier:
+  contacts: { label1: [] }

--- a/lib/bot/issue_manager.rb
+++ b/lib/bot/issue_manager.rb
@@ -144,6 +144,20 @@ EOMSG
     end
     if !valid_labels.empty?
       issue.add_labels(valid_labels)
+      notify_on_label(issue, valid_labels)
+    end
+  end
+
+  def notify_on_label(issue, labels)
+    labels.each do |label|
+      if Settings.label_notifier.contacts[label] &&
+         Settings.label_notifier.contacts[label] > 0
+        message = 'cc '
+        Settings.label_notifier.contacts[label].each do |contact|
+          message += "@#{contact}"
+        end
+        issue.add_comment(message)
+      end
     end
   end
 


### PR DESCRIPTION
Add the option to configure subscribers to specific labels. Once
subscribed to a label, miq_bot will add them to the cc list on every new
PR with configured label.