### PR TITLE
Fix #30 haml PR to list just the files on the command line.

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -35,8 +35,8 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
       @results = {"files" => []}
     else
 
-      @results = linter_results('rubocop', :files => files, :format => 'json')
-      haml = linter_results('haml-lint', :files => files, :reporter => 'json')
+      @results = linter_results('rubocop', :format => 'json', nil => files)
+      haml = linter_results('haml-lint', :reporter => 'json', nil => files)
 
       # Merge RuboCop and haml-lint results
       %w(offense_count target_file_count inspected_file_count).each do |m|


### PR DESCRIPTION
We don't want key/value pairs --files file1, file2, etc.
We want file1, file2, etc.

Fixes:
Executing: rubocop --files Gemfile --format json
invalid option: --files