### PR TITLE
Make gemfile checker a range handler.

### DIFF
--- a/app/models/commit_monitor_branch.rb
+++ b/app/models/commit_monitor_branch.rb
@@ -11,6 +11,8 @@ class CommitMonitorBranch < ActiveRecord::Base
   default_value_for(:commits_list) { [] }
   default_value_for :mergeable, true
 
+  delegate :enabled_for?, :to => :repo
+
   def self.with_branch_or_pr_number(n)
     n = MiqToolsServices::MiniGit.pr_branch(n) if n.kind_of?(Fixnum)
     where(:name => n)
@@ -18,11 +20,6 @@ class CommitMonitorBranch < ActiveRecord::Base
 
   def self.github_commit_uri(user, repo, sha = "$commit")
     "https://github.com/#{user}/#{repo}/commit/#{sha}"
-  end
-
-  def enabled_for?(checker)
-    repos = Settings.public_send(checker).enabled_repos
-    repo.fq_name.in?(repos)
   end
 
   def last_commit=(val)

--- a/app/models/commit_monitor_branch.rb
+++ b/app/models/commit_monitor_branch.rb
@@ -20,6 +20,11 @@ class CommitMonitorBranch < ActiveRecord::Base
     "https://github.com/#{user}/#{repo}/commit/#{sha}"
   end
 
+  def enabled_for?(checker)
+    repos = Settings.public_send(checker).enabled_repos
+    repo.fq_name.in?(repos)
+  end
+
   def last_commit=(val)
     super
     self.last_changed_on = Time.now.utc if last_commit_changed?

--- a/app/models/commit_monitor_repo.rb
+++ b/app/models/commit_monitor_repo.rb
@@ -59,4 +59,9 @@ class CommitMonitorRepo < ActiveRecord::Base
     Travis.github_auth(Settings.github_credentials.password)
     yield Travis::Repository.find(fq_name)
   end
+
+  def enabled_for?(checker)
+    repos = Settings.public_send(checker).enabled_repos
+    fq_name.in?(repos)
+  end
 end

--- a/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
@@ -20,7 +20,7 @@ module CommitMonitorHandlers
           return
         end
 
-        unless repo_enabled?
+        unless @branch.enabled_for?(:gemfile_checker)
           logger.info("(##{__method__}) #{self.class.name} only runs in " \
                       "#{enabled_repos}, not #{@branch.repo.fq_name}.  Skipping.")
           return
@@ -36,11 +36,6 @@ module CommitMonitorHandlers
       end
 
       private
-
-      def repo_enabled?
-        enabled_repos = Settings.gemfile_checker.enabled_repos
-        @branch.repo.fq_name.in?(enabled_repos)
-      end
 
       def diff_details_for_branch
         MiqToolsServices::MiniGit.call(branch.repo.path) do |git|

--- a/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
@@ -1,88 +1,101 @@
-class CommitMonitorHandlers::CommitRange::GemfileChecker
-  include Sidekiq::Worker
-  sidekiq_options :queue => :miq_bot
+module CommitMonitorHandlers
+  module CommitRange
+    class GemfileChecker
+      include Sidekiq::Worker
+      sidekiq_options :queue => :miq_bot
 
-  LABEL_NAME = "gem changes".freeze
+      LABEL_NAME = "gem changes".freeze
 
-  def self.handled_branch_modes
-    [:pr]
-  end
+      def self.handled_branch_modes
+        [:pr]
+      end
 
-  attr_reader :branch, :commits, :github, :pr
+      attr_reader :branch, :commits, :github, :pr
 
-  def perform(branch_id, new_commits)
-    @branch  = CommitMonitorBranch.where(:id => branch_id).first
+      def perform(branch_id, _new_commits)
+        @branch = CommitMonitorBranch.where(:id => branch_id).first
+        
+        if @branch.nil?
+          logger.info("Branch #{branch_id} no longer exists.  Skipping.")
+          return
+        end
 
-    if @branch.nil?
-      logger.info("Branch #{branch_id} no longer exists.  Skipping.")
-      return
+        unless repo_enabled?
+          logger.info("#{self.class} only runs in #{enabled_repos}, not #{@branch.repo.fq_name}.  Skipping.")
+          return
+        end
+
+        @pr      = @branch.pr_number
+        @commits = @branch.commits_list
+
+        files = diff_details_for_branch.keys
+        return unless files.any? { |f| File.basename(f) == "Gemfile" }
+
+        process_branch
+      end
+
+      private
+
+      def repo_enabled?
+        enabled_repos = Settings.gemfile_checker.enabled_repos
+        @branch.repo.fq_name.in?(enabled_repos)
+      end
+
+      def diff_details_for_branch
+        MiqToolsServices::MiniGit.call(branch.repo.path) do |git|
+          git.diff_details(commits.first, commits.last)
+        end
+      end
+
+      def tag
+        "<gemfile_checker />"
+      end
+
+      def gemfile_comment
+        "#{tag}#{Settings.gemfile_checker.pr_contacts.join(" ")} Gemfile " \
+        "changes detected in #{"commit".pluralize(commits.length)} " \
+        "#{commit_range}.  Please review."
+      end
+
+      def commit_range 
+        [
+          branch.commit_uri_to(commits.first),
+          branch.commit_uri_to(commits.last),
+        ].uniq.join(" .. ")
+      end
+
+      def process_branch
+        send("process_#{branch.pull_request? ? "pr" : "regular"}_branch")
+      end
+
+      def process_pr_branch
+        logger.info("#{self.class.name}##{__method__} Updating pull request #{pr} with Gemfile comment.")
+
+        branch.repo.with_github_service do |github|
+          @github = github
+          replace_gemfile_comments
+          add_pr_label
+        end
+      end
+
+      def replace_gemfile_comments
+        github.replace_issue_comments(pr, gemfile_comment) do |old_comment|
+          gemfile_comment?(old_comment)
+        end
+      end
+
+      def add_pr_label
+        logger.info("#{self.class.name}##{__method__} PR: #{pr}, Adding label: #{LABEL_NAME.inspect}")
+        github.add_issue_labels(pr, LABEL_NAME)
+      end
+
+      def gemfile_comment?(comment)
+        comment.body.start_with?(tag)
+      end
+
+      def process_regular_branch
+        # TODO: Support regular branches with EmailService once we can send email.
+      end
     end
-
-    enabled_repos = Settings.gemfile_checker.enabled_repos
-    unless @branch.repo.fq_name.in?(enabled_repos)
-      logger.info("#{self.class} only runs in #{enabled_repos}, not #{@branch.repo.fq_name}.  Skipping.")
-      return
-    end
-
-    @pr     = @branch.pr_number
-    @commits = @branch.commits_list
-
-    files = diff_details_for_branch.keys
-    return unless files.any? { |f| File.basename(f) == "Gemfile" }
-
-    process_branch
-  end
-
-  private
-
-  def diff_details_for_branch
-    MiqToolsServices::MiniGit.call(branch.repo.path) do |git|
-      git.diff_details(commits.first, commits.last)
-    end
-  end
-
-  def tag
-    "<gemfile_checker />"
-  end
-
-  def gemfile_comment
-    commit_range = [
-      branch.commit_uri_to(commits.first),
-      branch.commit_uri_to(commits.last),
-    ].uniq.join(" .. ")
-    "#{tag}#{Settings.gemfile_checker.pr_contacts.join(" ")} Gemfile changes detected in #{"commit".pluralize(commits.length)} #{commit_range}.  Please review."
-  end
-
-  def process_branch
-    send("process_#{branch.pull_request? ? "pr" : "regular"}_branch")
-  end
-
-  def process_pr_branch
-    logger.info("#{self.class.name}##{__method__} Updating pull request #{pr} with Gemfile comment.")
-
-    branch.repo.with_github_service do |github|
-      @github = github
-      replace_gemfile_comments
-      add_pr_label
-    end
-  end
-
-  def replace_gemfile_comments
-    github.replace_issue_comments(pr, gemfile_comment) do |old_comment|
-      gemfile_comment?(old_comment)
-    end
-  end
-
-  def add_pr_label
-    logger.info("#{self.class.name}##{__method__} PR: #{pr}, Adding label: #{LABEL_NAME.inspect}")
-    github.add_issue_labels(pr, LABEL_NAME)
-  end
-
-  def gemfile_comment?(comment)
-    comment.body.start_with?(tag)
-  end
-
-  def process_regular_branch
-    # TODO: Support regular branches with EmailService once we can send email.
   end
 end

--- a/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
@@ -16,12 +16,13 @@ module CommitMonitorHandlers
         @branch = CommitMonitorBranch.where(:id => branch_id).first
         
         if @branch.nil?
-          logger.info("Branch #{branch_id} no longer exists.  Skipping.")
+          logger.info("(##{__method__}) Branch #{branch_id} no longer exists.  Skipping.")
           return
         end
 
         unless repo_enabled?
-          logger.info("#{self.class} only runs in #{enabled_repos}, not #{@branch.repo.fq_name}.  Skipping.")
+          logger.info("(##{__method__}) #{self.class.name} only runs in " \
+                      "#{enabled_repos}, not #{@branch.repo.fq_name}.  Skipping.")
           return
         end
 
@@ -69,7 +70,7 @@ module CommitMonitorHandlers
       end
 
       def process_pr_branch
-        logger.info("#{self.class.name}##{__method__} Updating pull request #{pr} with Gemfile comment.")
+        logger.info("(##{__method__}) Updating pull request #{pr} with Gemfile comment.")
 
         branch.repo.with_github_service do |github|
           @github = github
@@ -85,7 +86,7 @@ module CommitMonitorHandlers
       end
 
       def add_pr_label
-        logger.info("#{self.class.name}##{__method__} PR: #{pr}, Adding label: #{LABEL_NAME.inspect}")
+        logger.info("(##{__method__}) PR: #{pr}, Adding label: #{LABEL_NAME.inspect}")
         github.add_issue_labels(pr, LABEL_NAME)
       end
 

--- a/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
@@ -14,7 +14,7 @@ module CommitMonitorHandlers
 
       def perform(branch_id, _new_commits)
         @branch = CommitMonitorBranch.where(:id => branch_id).first
-        
+
         if @branch.nil?
           logger.info("(##{__method__}) Branch #{branch_id} no longer exists.  Skipping.")
           return
@@ -53,7 +53,7 @@ module CommitMonitorHandlers
         "#{commit_range}.  Please review."
       end
 
-      def commit_range 
+      def commit_range
         [
           branch.commit_uri_to(commits.first),
           branch.commit_uri_to(commits.last),


### PR DESCRIPTION
The gemfile checker was a commit handler, so could generate more noise than was
required for PRs that had Gemfile changes over several commits. This changes it
to a commit range handler which allows only one comment for multiple Gemfile
changes.

https://trello.com/c/ts3G5COh/11-miq-bot-gemfile-checker-should-be-a-commit-range-handler-not-commit-handler
Fixes #78 

Below screenshot shows it now doing a single comment with a range of commits:

![screen shot 2015-06-26 at 2 43 12 pm](https://cloud.githubusercontent.com/assets/19339/8384817/bcc6ce30-1c11-11e5-9196-3323bffe75a0.png)