### PR TITLE
Add a repos folder, but ignore its contents.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 
 # Ignore production artifacts
 /public/assets
+
+# Ignore local repos folder
+/repos

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ problems.  Some of the things it does are:
 
 4. Add the sandbox app to the `repos` directory so it can be monitored:
    ```
-   mkdir repos
    git clone -o upstream git@github.com:miq-test/sandbox.git repos/sandbox
    ```
 


### PR DESCRIPTION
* Adds a `repos` folder so it does not need to be created in development steps
* Ignores anything in the `repos` folder so things added there for development are not tracked.
* Removes the corresponding step from the README