### PR TITLE
Use config/settings/development.local.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ problems.  Some of the things it does are:
 
 10. Configure the bot settings. First copy the template:
     ```
-    cp config/settings.yml config/settings.local.yml
+    cp config/settings.yml config/settings/development.local.yml
     ```
 
     Then set to the following values:


### PR DESCRIPTION
* Change the docs to indicate that
  `config/settings/development.local.yml` should be used instead of
  `config/settings.local.yml` so they are not available in the test environment.

Not sure about this, but I'm adding this with the thought that isolated tests should not change the world, so these settings should only be available for development. Any thoughts?