### PR TITLE
Bug/82/restart travis 3 times

### DIFF
--- a/app/workers/travis_event_handlers/stalled_finished_job.rb
+++ b/app/workers/travis_event_handlers/stalled_finished_job.rb
@@ -38,7 +38,7 @@ module TravisEventHandlers
 
       @branch = @repo.branches.with_branch_or_pr_number(pr_number).first
       if @branch.nil?
-        logger.warn("#{__method__} [#{slug}##{number}] Can't find CommitMonitorBranch with name: #{branch_or_pr_number}")
+        logger.warn("#{__method__} [#{slug}##{number}] Can't find CommitMonitorBranch with PR number: #{pr_number}")
         return
       end
 

--- a/app/workers/travis_event_handlers/stalled_finished_job.rb
+++ b/app/workers/travis_event_handlers/stalled_finished_job.rb
@@ -49,7 +49,7 @@ module TravisEventHandlers
         return
       end
 
-    # Remote checks: Skip missing travis repo or job and non-stalled builds
+      # Remote checks: Skip missing travis repo or job and non-stalled builds
       @repo.with_travis_service do |travis_repo|
         @job = find_job(travis_repo, number)
         if @job.nil?

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
     state = "errored"
     type = "job:finished"
     event_hash = new_event_hash(pr, slug, number, state, type)
-    repo = double("repo")
     job = double("job").as_null_object
     travis_repo = double("travis repo")
     allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([nil])

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
     described_class.new.perform(event_hash)
   end
 
-  it "restarts a stalled job" do
+  it "restarts a stalled, finished job" do
     pr = 123
     slug = "foo/bar"
     number = 42

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
       repo = double("repo")
       job = double("job").as_null_object
       travis_repo = double("travis repo")
-      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
+      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([repo])
       allow(travis_repo).to receive(:job).with(number).and_return(job)
 
       expect(job).not_to receive(:restart)
@@ -30,13 +30,50 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
       repo = double("repo")
       job = double("job").as_null_object
       travis_repo = double("travis repo")
-      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
+      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([repo])
       allow(travis_repo).to receive(:job).with(number).and_return(job)
 
       expect(job).not_to receive(:restart)
 
       described_class.new.perform(event_hash)
     end
+  end
+
+  it "skips if the repo cannot be found" do
+    pr = 123
+    slug = "foo/bar"
+    number = 42
+    state = "errored"
+    type = "job:finished"
+    event_hash = new_event_hash(pr, slug, number, state, type)
+    repo = double("repo")
+    job = double("job").as_null_object
+    travis_repo = double("travis repo")
+    allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([nil])
+    allow(travis_repo).to receive(:job).with(number).and_return(job)
+
+    expect(job).not_to receive(:restart)
+
+    described_class.new.perform(event_hash)
+  end
+
+  it "skips if the PR's branch cannot be found" do
+    pr = 123
+    slug = "foo/bar"
+    number = 42
+    state = "errored"
+    type = "job:finished"
+    event_hash = new_event_hash(pr, slug, number, state, type)
+    branches = double("branches", with_branch_or_pr_number: [nil])
+    repo = double("repo", branches: branches)
+    job = double("job").as_null_object
+    travis_repo = double("travis repo")
+    allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([repo])
+    allow(travis_repo).to receive(:job).with(number).and_return(job)
+
+    expect(job).not_to receive(:restart)
+
+    described_class.new.perform(event_hash)
   end
 
   it "skips after 3 tries" do
@@ -56,7 +93,7 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
                       .and_return([comment, comment, comment])
 
     allow(repo).to receive(:with_github_service).and_yield(github)
-    allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
+    allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([repo])
     allow(travis_repo).to receive(:job).with(number).and_return(job)
 
     expect(job).not_to receive(:restart)

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+RSpec.describe TravisEventHandlers::StalledFinishedJob do
+  %w(build:created build:started build:finished job:created job:started job:log).each do |type|
+    it "skips events of type #{type}" do
+      slug = "foo/bar"
+      number = 42
+      state = "errored"
+      event_hash = new_event_hash(slug, number, state, type)
+      repo = double("repo")
+      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
+      job = double("job").as_null_object
+      travis_repo = double("travis repo")
+      allow(travis_repo).to receive(:job).with(number).and_return(job)
+
+      expect(job).not_to receive(:restart)
+
+      described_class.new.perform(event_hash)
+    end
+  end
+  %w(created queued received started passed failed canceled ready).each do |state|
+    it "skips jobs that of state #{state}" do
+      slug = "foo/bar"
+      number = 42
+      type = "job:finished"
+      event_hash = new_event_hash(slug, number, state, type)
+      repo = double("repo")
+      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
+      job = double("job").as_null_object
+      travis_repo = double("travis repo")
+      allow(travis_repo).to receive(:job).with(number).and_return(job)
+
+      expect(job).not_to receive(:restart)
+
+      described_class.new.perform(event_hash)
+    end
+  end
+
+  def new_event_hash(slug, number, state, type)
+    {
+      "payload" => {
+        "repository_slug" => slug,
+        "number" => number,
+        "state" => state,
+      },
+      "type" => type,
+    }
+  end
+end

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -3,14 +3,15 @@ require "spec_helper"
 RSpec.describe TravisEventHandlers::StalledFinishedJob do
   %w(build:created build:started build:finished job:created job:started job:log).each do |type|
     it "skips events of type #{type}" do
+      pr = 123
       slug = "foo/bar"
       number = 42
       state = "errored"
-      event_hash = new_event_hash(slug, number, state, type)
+      event_hash = new_event_hash(pr, slug, number, state, type)
       repo = double("repo")
-      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
       job = double("job").as_null_object
       travis_repo = double("travis repo")
+      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
       allow(travis_repo).to receive(:job).with(number).and_return(job)
 
       expect(job).not_to receive(:restart)
@@ -18,16 +19,18 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
       described_class.new.perform(event_hash)
     end
   end
+
   %w(created queued received started passed failed canceled ready).each do |state|
-    it "skips jobs that of state #{state}" do
+    it "skips jobs of state #{state}" do
+      pr = 123
       slug = "foo/bar"
       number = 42
       type = "job:finished"
-      event_hash = new_event_hash(slug, number, state, type)
+      event_hash = new_event_hash(pr, slug, number, state, type)
       repo = double("repo")
-      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
       job = double("job").as_null_object
       travis_repo = double("travis repo")
+      allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
       allow(travis_repo).to receive(:job).with(number).and_return(job)
 
       expect(job).not_to receive(:restart)
@@ -36,8 +39,36 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
     end
   end
 
-  def new_event_hash(slug, number, state, type)
+  it "skips after 3 tries" do
+    pr = 123
+    slug = "foo/bar"
+    number = 42
+    state = "errored"
+    type = "job:finished"
+    event_hash = new_event_hash(pr, slug, number, state, type)
+    repo = double("repo").as_null_object
+    job = double("job").as_null_object
+    travis_repo = double("travis repo")
+    github = double("github")
+    comment = double("comment", body: described_class::COMMENT_TAG)
+
+    allow(github).to receive(:select_issue_comments).with(pr)
+                      .and_return([comment, comment, comment])
+
+    allow(repo).to receive(:with_github_service).and_yield(github)
+    allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return(repo)
+    allow(travis_repo).to receive(:job).with(number).and_return(job)
+
+    expect(job).not_to receive(:restart)
+
+    described_class.new.perform(event_hash)
+  end
+
+  def new_event_hash(pr, slug, number, state, type)
     {
+      "build" => {
+        "pull_request_number" => pr,
+      },
       "payload" => {
         "repository_slug" => slug,
         "number" => number,

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -177,9 +177,9 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
         "pull_request_number" => pr,
       },
       "payload" => {
-        "repository_slug"     => slug,
-        "number"              => number,
-        "state"               => state,
+        "repository_slug" => slug,
+        "number"          => number,
+        "state"           => state,
       },
       "type"    => type,
     }

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -101,6 +101,14 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
     described_class.new.perform(event_hash)
   end
 
+  it "skips if the job cannot be found" do
+    #
+  end
+
+  it "skips if the job is not stalled" do
+    #
+  end
+
   def new_event_hash(pr, slug, number, state, type)
     {
       "build" => {

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -148,6 +148,30 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
     described_class.new.perform(event_hash)
   end
 
+  it "restarts a stalled job" do
+    pr = 123
+    slug = "foo/bar"
+    number = 42
+    state = "errored"
+    type = "job:finished"
+    event_hash = new_event_hash(pr, slug, number, state, type)
+    repo = double("repo").as_null_object
+    job = double("job").as_null_object
+    travis_repo = double("travis repo")
+    github = double("github")
+
+    allow(github).to receive(:select_issue_comments).with(pr).and_return([])
+    allow(repo).to receive(:with_github_service).and_yield(github)
+    allow(repo).to receive(:with_travis_service).and_yield(travis_repo)
+    allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([repo])
+    allow(travis_repo).to receive(:job).with(number).and_return(job)
+    job.stub_chain(:log, :clean_body, :end_with?).and_return(true)
+
+    expect(job).to receive(:restart).once
+
+    described_class.new.perform(event_hash)
+  end
+
   def new_event_hash(pr, slug, number, state, type)
     {
       "build" => {

--- a/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
+++ b/spec/workers/travis_event_handlers/stalled_finished_job_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
     state = "errored"
     type = "job:finished"
     event_hash = new_event_hash(pr, slug, number, state, type)
-    branches = double("branches", with_branch_or_pr_number: [nil])
-    repo = double("repo", branches: branches)
+    branches = double("branches", :with_branch_or_pr_number => [nil])
+    repo = double("repo", :branches => branches)
     job = double("job").as_null_object
     travis_repo = double("travis repo")
     allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([repo])
@@ -87,10 +87,10 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
     job = double("job").as_null_object
     travis_repo = double("travis repo")
     github = double("github")
-    comment = double("comment", body: described_class::COMMENT_TAG)
+    comment = double("comment", :body => described_class::COMMENT_TAG)
 
     allow(github).to receive(:select_issue_comments).with(pr)
-                      .and_return([comment, comment, comment])
+      .and_return([comment, comment, comment])
 
     allow(repo).to receive(:with_github_service).and_yield(github)
     allow(CommitMonitorRepo).to receive(:with_slug).with(slug).and_return([repo])
@@ -174,15 +174,15 @@ RSpec.describe TravisEventHandlers::StalledFinishedJob do
 
   def new_event_hash(pr, slug, number, state, type)
     {
-      "build" => {
+      "build"   => {
         "pull_request_number" => pr,
       },
       "payload" => {
-        "repository_slug" => slug,
-        "number" => number,
-        "state" => state,
+        "repository_slug"     => slug,
+        "number"              => number,
+        "state"               => state,
       },
-      "type" => type,
+      "type"    => type,
     }
   end
 end


### PR DESCRIPTION
Stops the stalled job handler after 3 attempts to restart the travis build.

Note: I couldn't get the travis client to listen on my machine in development, so thus far have been unable to QA this bugfix. I've added tests in the meantime to help increase confidence here. The tests are pretty heavy on the setup side, but I've left them as is to add some pressure to maybe refactor the worker to reduce the number of dependencies it has.

Fixes https://github.com/ManageIQ/miq_bot/issues/82