### PR TITLE
Cleanup IssueManager credentials check.

### DIFF
--- a/app/workers/issue_manager_worker.rb
+++ b/app/workers/issue_manager_worker.rb
@@ -17,17 +17,17 @@ class IssueManagerWorker
       return
     end
 
-    repos = CommitMonitorRepo.where(:name => repo_names)
-    issue_managers = repos.collect { |r| IssueManager.new(r.upstream_user, r.name) }
-    issue_managers.each do |issue_manager|
-      with_error_handling { issue_manager.process_notifications }
+    CommitMonitorRepo.where(:name => repo_names).each do |repo|
+      process_notifications(repo)
     end
   end
 
-  def with_error_handling
-    yield
-  rescue => e
-    logger.error e.message
-    logger.error e.backtrace.join("\n")
+  private
+
+  def process_notifications(repo)
+    IssueManager.new(repo.upstream_user, repo.name).process_notifications
+  rescue => err
+    logger.error err.message
+    logger.error err.backtrace.join("\n")
   end
 end

--- a/lib/bot/issue_manager.rb
+++ b/lib/bot/issue_manager.rb
@@ -24,7 +24,10 @@ class IssueManager
   ).freeze
 
   def initialize(organization_name, repo_name)
-    get_credentials
+    @username     = Settings.github_credentials.username
+    @password     = Settings.github_credentials.password
+    raise "no GitHub credentials defined" if @username.nil? || @password.nil?
+
     @fq_repo_name = "#{organization_name}/#{repo_name}"
     @user         = GitHubApi.connect(@username, @password)
     @org          = @user.find_organization(organization_name)
@@ -171,16 +174,6 @@ EOMSG
 
     # Then see if any are *still* invalid and split the list
     label_names.partition { |l| @repo.valid_label?(l) }
-  end
-
-  def get_credentials
-    @username = Settings.github_credentials.username
-    @password = Settings.github_credentials.password
-
-    if @username.nil? || @password.nil?
-      logger.error("Credentials are not configured. Exiting..")
-      exit 1
-    end
   end
 
   def timestamps

--- a/spec/workers/issue_manager_worker_spec.rb
+++ b/spec/workers/issue_manager_worker_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe IssueManagerWorker do
       subject.perform
     end
 
-    it "recovers from errors raised by an issue manager" do
+    it "handles errors raised by an issue manager" do
       im1, im2 = stub_issue_managers(["SomeOrg", "some_repo1"], ["SomeOrg", "some_repo2"])
 
       expect(im1).to receive(:process_notifications).once.and_raise("boom")


### PR DESCRIPTION
Removes the `exit 1` that could kill the whole bot.