### PR TITLE
Rename models

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ underscores replaced with hyphens.
 
 7. Add the test repository to the database:
    ```
-   bundle exec rails runner 'CommitMonitorRepo.create_from_github!("miq-test", "sandbox", Rails.root.join("repos", "sandbox"))'
+   bundle exec rails runner 'Repo.create_from_github!("miq-test", "sandbox", Rails.root.join("repos", "sandbox"))'
    ```
 
 8. Create a custom Procfile for development. Any changes you make to this file

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -1,5 +1,5 @@
 class MainController < ApplicationController
   def index
-    @branches = CommitMonitorBranch.includes(:repo).sort_by { |b| [b.repo.name, b.name] }
+    @branches = Branch.includes(:repo).sort_by { |b| [b.repo.name, b.name] }
   end
 end

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -1,5 +1,5 @@
-class CommitMonitorBranch < ActiveRecord::Base
-  belongs_to :repo, :class_name => :CommitMonitorRepo, :foreign_key => :commit_monitor_repo_id
+class Branch < ActiveRecord::Base
+  belongs_to :repo, :foreign_key => :commit_monitor_repo_id
 
   validates :name,        :presence => true, :uniqueness => {:scope => :repo}
   validates :commit_uri,  :presence => true

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -1,5 +1,5 @@
 class Branch < ActiveRecord::Base
-  belongs_to :repo, :foreign_key => :commit_monitor_repo_id
+  belongs_to :repo
 
   validates :name,        :presence => true, :uniqueness => {:scope => :repo}
   validates :commit_uri,  :presence => true

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -1,5 +1,5 @@
-class CommitMonitorRepo < ActiveRecord::Base
-  has_many :branches, :class_name => :CommitMonitorBranch, :dependent => :destroy
+class Repo < ActiveRecord::Base
+  has_many :branches, :dependent => :destroy, :foreign_key => "commit_monitor_repo_id"
 
   validates :name, :presence => true, :uniqueness => true
   validates :path, :presence => true, :uniqueness => true
@@ -17,7 +17,7 @@ class CommitMonitorRepo < ActiveRecord::Base
 
       repo.branches.create!(
         :name        => "master",
-        :commit_uri  => CommitMonitorBranch.github_commit_uri(upstream_user, name),
+        :commit_uri  => Branch.github_commit_uri(upstream_user, name),
         :last_commit => git.current_ref
       )
 
@@ -33,7 +33,7 @@ class CommitMonitorRepo < ActiveRecord::Base
   # fq_name: "ManageIQ/miq_bot"
   def self.with_fq_name(fq_name)
     user, repo = fq_name.split("/")
-    CommitMonitorRepo.where(:upstream_user => user, :name => repo)
+    where(:upstream_user => user, :name => repo)
   end
   class << self
     alias_method :with_slug, :with_fq_name

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -1,5 +1,5 @@
 class Repo < ActiveRecord::Base
-  has_many :branches, :dependent => :destroy, :foreign_key => "commit_monitor_repo_id"
+  has_many :branches, :dependent => :destroy
 
   validates :name, :presence => true, :uniqueness => true
   validates :path, :presence => true, :uniqueness => true

--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -45,7 +45,7 @@ class CommitMonitor
   attr_reader :repo, :git, :branch, :new_commits, :all_commits, :statistics
 
   def process_branches
-    CommitMonitorRepo.includes(:branches).each do |repo|
+    Repo.includes(:branches).each do |repo|
       @statistics = {}
 
       @repo = repo

--- a/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
+++ b/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
@@ -9,7 +9,7 @@ class CommitMonitorHandlers::Branch::PrMergeabilityChecker
   attr_reader :branch
 
   def perform(branch_id)
-    @branch = CommitMonitorBranch.where(:id => branch_id).first
+    @branch = Branch.where(:id => branch_id).first
 
     if @branch.nil?
       logger.info("Branch #{branch_id} no longer exists.  Skipping.")

--- a/app/workers/commit_monitor_handlers/commit/bugzilla_commenter.rb
+++ b/app/workers/commit_monitor_handlers/commit/bugzilla_commenter.rb
@@ -16,7 +16,7 @@ module CommitMonitorHandlers
 
       def perform(branch_id, commit, commit_details)
         logger.info("Performing bugzilla check on branch #{branch_id}")
-        @branch  = CommitMonitorBranch.where(:id => branch_id).first
+        @branch  = Branch.where(:id => branch_id).first
         @commit  = commit
         @message = commit_details["message"]
 

--- a/app/workers/commit_monitor_handlers/commit/bugzilla_pr_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit/bugzilla_pr_checker.rb
@@ -16,7 +16,7 @@ module CommitMonitorHandlers
 
       def perform(branch_id, commit, commit_details)
         logger.info("Performing bugzilla PR check on branch #{branch_id}")
-        @branch  = CommitMonitorBranch.where(:id => branch_id).first
+        @branch  = Branch.where(:id => branch_id).first
         @commit  = commit
         @message = commit_details["message"]
 

--- a/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/gemfile_checker.rb
@@ -13,7 +13,7 @@ module CommitMonitorHandlers
       attr_reader :branch, :commits, :github, :pr
 
       def perform(branch_id, _new_commits)
-        @branch = CommitMonitorBranch.where(:id => branch_id).first
+        @branch = Branch.where(:id => branch_id).first
 
         if @branch.nil?
           logger.info("(##{__method__}) Branch #{branch_id} no longer exists.  Skipping.")

--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -9,7 +9,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
   attr_reader :branch, :pr, :commits, :results, :github
 
   def perform(branch_id, new_commits)
-    @branch  = CommitMonitorBranch.where(:id => branch_id).first
+    @branch  = Branch.where(:id => branch_id).first
 
     if @branch.nil?
       logger.info("Branch #{branch_id} no longer exists.  Skipping.")

--- a/app/workers/issue_manager_worker.rb
+++ b/app/workers/issue_manager_worker.rb
@@ -17,7 +17,7 @@ class IssueManagerWorker
       return
     end
 
-    CommitMonitorRepo.where(:name => repo_names).each do |repo|
+    Repo.where(:name => repo_names).each do |repo|
       process_notifications(repo)
     end
   end

--- a/app/workers/pull_request_monitor.rb
+++ b/app/workers/pull_request_monitor.rb
@@ -10,7 +10,7 @@ class PullRequestMonitor
     if !first_unique_worker?
       logger.info "#{self.class} is already running, skipping"
     else
-      CommitMonitorRepo.includes(:branches).each do |repo|
+      Repo.includes(:branches).each do |repo|
         next unless repo.upstream_user
         RepoProcessor.process(repo)
       end

--- a/app/workers/travis_build_killer.rb
+++ b/app/workers/travis_build_killer.rb
@@ -19,7 +19,7 @@ class TravisBuildKiller
   attr_accessor :repo
 
   def process_repo
-    @repo = CommitMonitorRepo.where(:upstream_user => "ManageIQ", :name => "manageiq").first
+    @repo = Repo.where(:upstream_user => "ManageIQ", :name => "manageiq").first
     if @repo.nil?
       logger.info "The ManageIQ/manageiq repo has not been defined.  Skipping."
       return

--- a/app/workers/travis_event_handlers/stalled_finished_job.rb
+++ b/app/workers/travis_event_handlers/stalled_finished_job.rb
@@ -28,15 +28,15 @@ module TravisEventHandlers
         return
       end
 
-      @repo = CommitMonitorRepo.with_slug(slug).first
+      @repo = Repo.with_slug(slug).first
       if @repo.nil?
-        logger.warn("#{__method__} [#{slug}##{number}] Can't find CommitMonitorRepo.")
+        logger.warn("#{__method__} [#{slug}##{number}] Can't find Repo.")
         return
       end
 
       @branch = @repo.branches.with_branch_or_pr_number(pr_number).first
       if @branch.nil?
-        logger.warn("#{__method__} [#{slug}##{number}] Can't find CommitMonitorBranch with name: #{branch_or_pr_number}")
+        logger.warn("#{__method__} [#{slug}##{number}] Can't find Branch with name: #{branch_or_pr_number}")
         return
       end
 

--- a/db/migrate/20150814183817_rename_commit_monitor_repos_to_repos.rb
+++ b/db/migrate/20150814183817_rename_commit_monitor_repos_to_repos.rb
@@ -1,0 +1,5 @@
+class RenameCommitMonitorReposToRepos < ActiveRecord::Migration
+  def change
+    rename_table :commit_monitor_repos, :repos
+  end
+end

--- a/db/migrate/20150814183834_rename_commit_monitor_branches_to_branches.rb
+++ b/db/migrate/20150814183834_rename_commit_monitor_branches_to_branches.rb
@@ -1,0 +1,5 @@
+class RenameCommitMonitorBranchesToBranches < ActiveRecord::Migration
+  def change
+    rename_table :commit_monitor_branches, :branches
+  end
+end

--- a/db/migrate/20150814191457_rename_branches_foreign_key.rb
+++ b/db/migrate/20150814191457_rename_branches_foreign_key.rb
@@ -1,0 +1,5 @@
+class RenameBranchesForeignKey < ActiveRecord::Migration
+  def change
+    rename_column :branches, :commit_monitor_repo_id, :repo_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150814183834) do
+ActiveRecord::Schema.define(version: 20150814191457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20150814183834) do
     t.string   "name"
     t.string   "commit_uri"
     t.string   "last_commit"
-    t.integer  "commit_monitor_repo_id"
+    t.integer  "repo_id"
     t.boolean  "pull_request"
     t.datetime "last_checked_on"
     t.datetime "last_changed_on"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140215060546) do
+ActiveRecord::Schema.define(version: 20150814183834) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "commit_monitor_branches", force: true do |t|
+  create_table "branches", force: true do |t|
     t.string   "name"
     t.string   "commit_uri"
     t.string   "last_commit"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20140215060546) do
     t.boolean  "mergeable"
   end
 
-  create_table "commit_monitor_repos", force: true do |t|
+  create_table "repos", force: true do |t|
     t.string   "name"
     t.string   "path"
     t.datetime "created_at"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,7 +1,7 @@
 namespace :data do
   desc "Backup the Repos and branches to a YAML file"
   task :backup => :environment do
-    data = CommitMonitorRepo.all.collect do |repo|
+    data = Repo.all.collect do |repo|
       branches = repo.branches.all.collect do |branch|
         {
           "name"            => branch.name,
@@ -32,14 +32,14 @@ namespace :data do
     data = YAML.load(File.read(path))
 
     data.each do |repo|
-      ar_repo = CommitMonitorRepo.create!(
+      ar_repo = Repo.create!(
         :name          => repo["name"],
         :path          => repo["path"],
         :upstream_user => repo["upstream_user"],
       )
 
       repo["branches"].each do |branch|
-        CommitMonitorBranch.create!(
+        Branch.create!(
           :name            => branch["name"],
           :commit_uri      => branch["commit_uri"],
           :last_commit     => branch["last_commit"],

--- a/spec/factories/branch.rb
+++ b/spec/factories/branch.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :branch, :class => CommitMonitorBranch do
+  factory :branch do
     sequence(:name)  { |n| "fix/issue/#{n}" }
     commit_uri "https://example.com/foo/bar/commit/$commit"
     last_commit Digest::SHA1.hexdigest "contents of last commit"

--- a/spec/factories/repo.rb
+++ b/spec/factories/repo.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :repo, :class => CommitMonitorRepo do
+  factory :repo do
     sequence(:name) { |n| "repo_#{n}" }
     path { "/path/to/repos/#{name}" }
   end

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe CommitMonitorBranch do
+describe Branch do
   let(:last_commit)  { "123abc" }
   let(:other_commit) { "234def" }
 
   let(:repo) do
-    CommitMonitorRepo.create!(
+    Repo.create!(
       :upstream_user => "test-user",
       :name          => "test-repo",
       :path          => "/path/to/repo"
@@ -13,7 +13,7 @@ describe CommitMonitorBranch do
   end
 
   let(:branch) do
-    CommitMonitorBranch.create!(
+    Branch.create!(
       :name        => "test-branch",
       :repo        => repo,
       :last_commit => last_commit,
@@ -23,12 +23,12 @@ describe CommitMonitorBranch do
 
   context ".github_commit_uri" do
     it "(user, repo)" do
-      actual = CommitMonitorBranch.github_commit_uri("ManageIQ", "sandbox")
+      actual = Branch.github_commit_uri("ManageIQ", "sandbox")
       expect(actual).to eq("https://github.com/ManageIQ/sandbox/commit/$commit")
     end
 
     it "(user, repo, sha)" do
-      actual = CommitMonitorBranch.github_commit_uri("ManageIQ", "sandbox", "3616fc8ea9cfbcc2a7f70b8870f4a736ce6c91d5")
+      actual = Branch.github_commit_uri("ManageIQ", "sandbox", "3616fc8ea9cfbcc2a7f70b8870f4a736ce6c91d5")
       expect(actual).to eq("https://github.com/ManageIQ/sandbox/commit/3616fc8ea9cfbcc2a7f70b8870f4a736ce6c91d5")
     end
   end

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe CommitMonitorRepo do
+describe Repo do
   let(:repo) do
-    CommitMonitorRepo.new(
+    Repo.new(
       :upstream_user => "some_user",
       :name          => "some_repo"
     )

--- a/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder do
   let(:branch) do
-    CommitMonitorBranch.new(
+    Branch.new(
       :name         => "pr/123",
       :commit_uri   => "https://github.com/some_user/some_repo/commit/$commit",
       :last_commit  => "8942a195a0bfa69ceb82c020c60565408cb46d3e",

--- a/spec/workers/issue_manager_worker_spec.rb
+++ b/spec/workers/issue_manager_worker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IssueManagerWorker do
   def stub_issue_managers(*org_repo_pairs)
     allow(Settings).to receive_message_chain(:issue_manager, :repo_names).and_return(org_repo_pairs.collect(&:last))
     org_repo_pairs.collect.with_index do |(org_name, repo_name), i|
-      CommitMonitorRepo.create!(
+      Repo.create!(
         :name          => repo_name,
         :upstream_user => org_name,
         :path          => Rails.root.join("repos/#{repo_name}")

--- a/spec/workers/pull_request_monitor/pr_branch_record_spec.rb
+++ b/spec/workers/pull_request_monitor/pr_branch_record_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe PullRequestMonitor::PrBranchRecord do
   describe ".create" do
     it "has git create a local pr branch" do
-      repo = spy("CommitMonitorRepo")
+      repo = spy("Repo")
       pr = spy("pr")
       branch_name = "foo/bar"
       git = spy("git")
@@ -15,7 +15,7 @@ RSpec.describe PullRequestMonitor::PrBranchRecord do
     end
 
     it "creates a PR branch on the repo" do
-      repo = instance_spy("CommitMonitorRepo")
+      repo = instance_spy("Repo")
       pr = spy("pr")
       branch_name = "foo/bar"
       last_commit = "123456"
@@ -39,7 +39,7 @@ RSpec.describe PullRequestMonitor::PrBranchRecord do
 
   describe ".delete" do
     it "does nothing if given no branch names" do
-      repo = spy("CommitMonitorRepo")
+      repo = spy("Repo")
       git = spy("git")
       allow(repo).to receive(:with_git_service).and_yield(git)
 
@@ -50,7 +50,7 @@ RSpec.describe PullRequestMonitor::PrBranchRecord do
     end
 
     it "destroys the repo's branch matching the name given" do
-      repo = instance_spy("CommitMonitorRepo")
+      repo = instance_spy("Repo")
       branch_name = "foo/bar"
       relation = spy("relation")
       allow(repo).to receive(:branches).and_return(relation)
@@ -62,7 +62,7 @@ RSpec.describe PullRequestMonitor::PrBranchRecord do
     end
 
     it "can destroy multiple branches" do
-      repo = instance_spy("CommitMonitorRepo")
+      repo = instance_spy("Repo")
       branch_1 = "foo/bar"
       branch_2 = "baz/qux"
       relation = spy("relation")
@@ -75,7 +75,7 @@ RSpec.describe PullRequestMonitor::PrBranchRecord do
     end
 
     it "has git delete the local branches" do
-      repo = spy("CommitMonitorRepo")
+      repo = spy("Repo")
       git = spy("git")
       allow(repo).to receive(:with_git_service).and_yield(git)
       branch_name = "foo/bar"
@@ -88,7 +88,7 @@ RSpec.describe PullRequestMonitor::PrBranchRecord do
 
   describe ".prune" do
     it "prunes the stale pr branches" do
-      repo = instance_spy("CommitMonitorRepo")
+      repo = instance_spy("Repo")
       git = spy("git")
       branch_name = "foo/bar"
       allow(repo).to receive(:with_git_service).and_yield(git)


### PR DESCRIPTION
don't think there's an issue for this, but I'm pretty sure we talked about this change:

* `CommitMonitorRepo` => `Repo`
* `CommitMonitorBranch` => `Branch`