### PR TITLE
Print the ruby version in rubocop comments

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
@@ -43,7 +43,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
   end
 
   def header
-    header1 = "Checked #{"commit".pluralize(commits.length)} #{commit_range_text} with rubocop #{rubocop_version} and haml-lint #{hamllint_version}"
+    header1 = "Checked #{"commit".pluralize(commits.length)} #{commit_range_text} with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}"
 
     file_count    = results.fetch_path("summary", "target_file_count").to_i
     offense_count = results.fetch_path("summary", "offense_count").to_i

--- a/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
@@ -20,7 +20,7 @@ describe CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder do
     it "with results with offenses" do
       expect(subject.length).to eq 1
       expect(subject.first).to  eq <<-EOMSG
-<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version} and haml-lint #{hamllint_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}
 4 files checked, 4 offenses detected
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb**
@@ -38,7 +38,7 @@ describe CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder do
     it "with results with no offenses" do
       expect(subject.length).to eq 1
       expect(subject.first).to  start_with <<-EOMSG.chomp
-<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version} and haml-lint #{hamllint_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}
 1 file checked, 0 offenses detected
 Everything looks good.
       EOMSG
@@ -48,7 +48,7 @@ Everything looks good.
     it "with results generating multiple comments" do
       expect(subject.length).to eq 2
       expect(subject.first).to  start_with <<-EOMSG.chomp
-<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with rubocop #{rubocop_version} and haml-lint #{hamllint_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}
 1 file checked, 194 offenses detected
       EOMSG
       expect(subject.last).to   start_with "<rubocop />**...continued**\n"


### PR DESCRIPTION
Sometimes, rubocop will be running on a different ruby version than
the developer who opened the pull request.

This leads to very :confused: developers as rubocop could report
syntax errors such as %i (added in 2.0) if the bot is using ruby 1.9.3.

Printing the ruby version may help clarify why it's invalid syntax.

Fixes #114