### PR TITLE
[POC] Add a preferred methods cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+require:
+  - /home/tim/src/miq_bot/lib/rubocop/cop/manageiq/preferred_methods

--- a/lib/rubocop/cop/manageiq/preferred_methods.rb
+++ b/lib/rubocop/cop/manageiq/preferred_methods.rb
@@ -1,0 +1,31 @@
+module RuboCop
+  module Cop
+    module ManageIQ
+      class PreferredMethods < Cop
+        MSG = "Prefer `%s` over `%s`."
+
+        def on_send(node)
+          _receiver, method_name, *_args = *node
+          return unless preferred_methods[method_name]
+          add_offense(node, :selector,
+                      format(MSG,
+                             preferred_method(method_name),
+                             method_name)
+                     )
+        end
+
+        private
+
+        def preferred_methods
+          {
+            :intern => :to_sym
+          }
+        end
+
+        def preferred_method(method)
+          preferred_methods[method.to_sym]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a proof of concept and as such should not be merged as-is. It
has the following issues:

* creates a `rubocop.yml` file, and one is already symlinked in
  production
* in that file it has an absolute path to a file that is not on the
  load-path when executing `rubocop` through awesome spawn

Nonetheless, I've added a new custom cop more or less as suggested in
https://github.com/bbatsov/rubocop#custom-cops which will provide a
framework to customize a set of preferred methods. At present it just
covers `to_sym` over `intern`. It can be seen in action over in this PR:
https://github.com/miq-test/sandbox/pull/26

I'm open to suggestion over how to proceed with this.

Resolves https://github.com/ManageIQ/miq_bot/issues/7