### PR TITLE
Clear out new_commits_details cache for each branch

### DIFF
--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -64,6 +64,7 @@ class CommitMonitor
         sorted_branches = repo.branches.sort_by { |b| b.pull_request? ? 1 : -1 }
 
         sorted_branches.each do |branch|
+          @new_commits_details = nil
           @branch = branch
           process_branch
         end


### PR DESCRIPTION
The persistent cache was causing the bot to post PR links to bugzilla tickets
when the BZ had not been referenced in any of the PR's commit messages.

This could happen when an earlier PR branch had a BZ URI in one of
the commit messages that got stored in the `@new_commits_details` cache.
In that case we would iterate through the first (BZ) branch's commits
as well as the new branch commits during processing, causing us to see the
BZ URI in the context of the new branch.