### PR TITLE
Use the common miq_tools_services github_api method

### DIFF
--- a/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
+++ b/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
@@ -36,10 +36,7 @@ class CommitMonitorHandlers::Branch::PrMergeabilityChecker
     logger.info("Updating PR #{branch.pr_number} with mergability comment.")
 
     branch.repo.with_github_service do |github|
-      github.issues.comments.create(
-        :issue_id => branch.pr_number,
-        :body     => "#{tag}This pull request is not mergeable.  Please rebase and repush."
-      )
+      github.create_issue_comments(branch.pr_number, "#{tag}This pull request is not mergeable.  Please rebase and repush.")
     end
   end
 end


### PR DESCRIPTION
https://github.com/ManageIQ/miq_tools_services/blob/cee3bd5e26fb692ee62aca5023e2b7264f017847/lib/miq_tools_services/github.rb#L40-L47

@Fryguy @bdunne Saw this when I was trying to run the bot in "read-only" github mode.  I had to manually modify this line to prevent it from writing to github.  The only other places I had to make it "read-only" were the modification methods in MiqToolsServices, which is the goal.