### PR TITLE
Force the bot to only load repos from the repos directory.

### DIFF
--- a/db/migrate/20151207193108_remove_path_from_repo.rb
+++ b/db/migrate/20151207193108_remove_path_from_repo.rb
@@ -1,0 +1,5 @@
+class RemovePathFromRepo < ActiveRecord::Migration
+  def change
+    remove_column :repos, :path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150827194533) do
+ActiveRecord::Schema.define(version: 20151207193108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "batch_entries", force: :cascade do |t|
     t.integer "batch_job_id"
-    t.string  "state"
+    t.string  "state",        limit: 255
     t.text    "result"
   end
 
@@ -28,15 +28,15 @@ ActiveRecord::Schema.define(version: 20150827194533) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "expires_at"
-    t.string   "on_complete_class"
+    t.string   "on_complete_class", limit: 255
     t.text     "on_complete_args"
-    t.string   "state"
+    t.string   "state",             limit: 255
   end
 
   create_table "branches", force: :cascade do |t|
-    t.string   "name"
-    t.string   "commit_uri"
-    t.string   "last_commit"
+    t.string   "name",            limit: 255
+    t.string   "commit_uri",      limit: 255
+    t.string   "last_commit",     limit: 255
     t.integer  "repo_id"
     t.boolean  "pull_request"
     t.datetime "last_checked_on"
@@ -46,8 +46,7 @@ ActiveRecord::Schema.define(version: 20150827194533) do
   end
 
   create_table "repos", force: :cascade do |t|
-    t.string   "name"
-    t.string   "path"
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/factories/repo.rb
+++ b/spec/factories/repo.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :repo do
     sequence(:name) { |n| "SomeUser/repo_#{n}" }
-    path            { "/path/to/repos/#{name}" }
   end
 end

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -44,18 +44,9 @@ describe Repo do
     end
   end
 
-  context "#path / #path=" do
-    let(:home) { File.expand_path("~") }
-
-    it "with expandable path" do
-      repo.path = "~/path"
-      expect(repo.path).to eq File.expand_path("~/path")
-    end
-
-    it "with absolute path" do
-      repo.path = "/Users/me/path"
-      expect(repo.path).to eq "/Users/me/path"
-    end
+  it "#path" do
+    expected = Rails.root.join("repos", repo.name)
+    expect(repo.path).to eq(expected)
   end
 
   it "#branch_names" do


### PR DESCRIPTION
@bdunne Please review.  I think this should go at the same time as https://github.com/ManageIQ/miq_tools_services/pull/19

Note that this depends on https://github.com/ManageIQ/miq_tools_services/pull/20 (clone support) getting released.