### PR TITLE
Retain only new commits for non-PR branches.

### DIFF
--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -77,10 +77,9 @@ class CommitMonitor
     update_branch
 
     @new_commits, @all_commits = detect_commits
-    statistics[branch.name] = {
-      :new_commits => new_commits,
-      :all_commits => all_commits
-    }
+
+    statistics[branch.name] = {:new_commits => new_commits} unless branch.pull_request?
+
     logger.info "Detected new commits #{new_commits}" if new_commits.any?
 
     save_branch_record


### PR DESCRIPTION
The statistics hash is retained through the life of one run of the
commit monitor, which can traverse 100+ branches, so all commits and
new commits for all branches is a lot of data.

We currently only care about "master" so we can compare PRs against
any new commits to "master".  Using Branch#pull_request? will allow
us to use non-master branches at some point.

Additionally, we don't ever use statistics[:all_commits] so don't
store it.