### PR TITLE
[WIP] Feature: Auto-add WIP label by title

### DIFF
--- a/app/models/git_hub_api/issue.rb
+++ b/app/models/git_hub_api/issue.rb
@@ -62,6 +62,10 @@ module GitHubApi
       end
     end
 
+    def title_indicates_wip?
+      !!(@title =~ /\[WIP\]/i)
+    end
+
     private
 
     def update(options)

--- a/app/models/github_notification_monitor.rb
+++ b/app/models/github_notification_monitor.rb
@@ -53,9 +53,18 @@ class GithubNotificationMonitor
   end
 
   def process_issue_thread(issue)
+    process_issue_title(issue)
     process_issue_comment(issue, issue.author, issue.created_at, issue.body)
     issue.comments.each do |comment|
       process_issue_comment(comment.issue, comment.author, comment.updated_at, comment.body)
+    end
+  end
+
+  def process_issue_title(issue)
+    if issue.title_indicates_wip?
+      issue.add_labels([GitHubApi::Label.new(nil, "wip", nil)]) unless issue.applied_label?("wip")
+    else
+      issue.remove_label("wip") if issue.applied_label?("wip")
     end
   end
 


### PR DESCRIPTION
This is a quick stab at auto-assigning the WIP label to any issues titled as WIP. It's pretty simplistic and doesn't include any specs - honestly, if we want to wait for them I'd rather do some refactoring first as trying to add them was a nightmare without changing a ton of unrelated specs and I give up for now for such a small change.

Note that one limitation here is that issue/PR renames are _not_ included in GitHub's Notification API, meaning the bot doesn't actively add/remove the label unless some other notification has triggered it. That is, it'll be labeled upon first opening the PR, but won't be labeled if someone changes the title mid way through until someone comments, it's closed, merged, etc.