### PR TITLE
Remove comment and needinfo flag when BZ is referenced after ONDEV state

### DIFF
--- a/app/workers/commit_monitor_handlers/commit/bugzilla_pr_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit/bugzilla_pr_checker.rb
@@ -62,10 +62,6 @@ module CommitMonitorHandlers
         when "NEW", "ASSIGNED"
           logger.info "Changing status of bug #{bug_id} to ON_DEV."
           bug.status = "ON_DEV"
-        else
-          logger.warn "Not changing status of bug #{bug_id} from #{bug_stat}."
-          bug.add_comment("Detected commit referencing this ticket while ticket status is #{bug_stat}.")
-          bug.flags["needinfo"] = "?"
         end
       end
     end


### PR DESCRIPTION
This will avoid issues like the one that happenend here https://bugzilla.redhat.com/show_bug.cgi?id=1296248 where the bot comments and sets needinfo when there was a bad rebase.