### PR TITLE
Fix rugged diffs for rubocopping

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -80,27 +80,7 @@ class Branch < ActiveRecord::Base
     end
   end
 
-  def branch_ref_name
-    return name if name.include?("prs/")
-    "origin/#{name}"
-  end
-
-  def git_diff
-    rugged_repo.diff(git_merge_base, branch_ref_name)
-  end
-
-  def git_branch_ref
-    rugged_repo.references["refs/#{branch_ref_name}"]
-  end
-
-  def git_merge_base
-    rugged_repo.merge_base("refs/#{branch_ref_name}", "origin/#{merge_target}")
-  end
-
-  private
-
-  def rugged_repo
-    require 'rugged'
-    Rugged::Repository.new(repo.path.to_s)
+  def git_service
+    GitService::Branch.new(self)
   end
 end

--- a/app/workers/pull_request_monitor/pr_branch_record.rb
+++ b/app/workers/pull_request_monitor/pr_branch_record.rb
@@ -10,7 +10,7 @@ class PullRequestMonitor
         :pull_request => true,
         :merge_target => pr.base.ref
       )
-      branch.last_commit = branch.git_merge_base
+      branch.last_commit = branch.git_service.merge_base
       branch.save!
     end
 

--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -1,0 +1,53 @@
+require 'rugged'
+
+module GitService
+  class Branch
+    attr_reader :branch
+    def initialize(branch)
+      @branch = branch
+    end
+
+    def blob_at(path) # Rugged::Blob object for a given file path on this branch
+      blob_data = merge_tree.path(path)
+      blob = Rugged::Blob.lookup(rugged_repo, blob_data[:oid])
+      (blob.type == :blob) ? blob : nil
+    rescue Rugged::TreeError
+    end
+
+    def diff
+      Diff.new(target_for_reference(merge_target_ref_name).diff(merge_tree))
+    end
+
+    def merge_base
+      rugged_repo.merge_base(target_for_reference(merge_target_ref_name), target_for_reference(ref_name))
+    end
+
+    def merge_index # Rugged::Index for a merge of this branch
+      rugged_repo.merge_commits(target_for_reference(merge_target_ref_name), target_for_reference(ref_name))
+    end
+
+    def merge_tree # Rugged::Tree object for the merge of this branch
+      tree_ref = merge_index.write_tree(rugged_repo)
+      rugged_repo.lookup(tree_ref)
+    end
+
+    def target_for_reference(reference) # Rugged::Commit for a given refname i.e. "refs/remotes/origin/master"
+      rugged_repo.references[reference].target
+    end
+
+    private
+
+    def ref_name
+      return "refs/#{branch.name}" if branch.name.include?("prs/")
+      "refs/remotes/origin/#{branch.name}"
+    end
+
+    def merge_target_ref_name
+      "refs/remotes/origin/#{branch.merge_target}"
+    end
+
+    def rugged_repo
+      Rugged::Repository.new(branch.repo.path.to_s)
+    end
+  end
+end

--- a/lib/git_service/diff.rb
+++ b/lib/git_service/diff.rb
@@ -1,0 +1,28 @@
+module GitService
+  class Diff
+    attr_reader :raw_diff
+    def initialize(raw_diff)
+      @raw_diff = raw_diff
+    end
+
+    def new_files
+      raw_diff.deltas.collect { |delta| delta.try(:new_file).try(:[], :path) }.compact
+    end
+
+    def with_each_patch
+      raw_diff.patches.each { |patch| yield(patch) }
+    end
+
+    def with_each_hunk
+      with_each_patch do |patch|
+        patch.hunks.each { |hunk| yield(hunk, patch) }
+      end
+    end
+
+    def with_each_line
+      with_each_hunk do |hunk, parent_patch|
+        hunk.lines.each { |line| yield(line, hunk, parent_patch) }
+      end
+    end
+  end
+end

--- a/lib/linter/rubocop.rb
+++ b/lib/linter/rubocop.rb
@@ -28,17 +28,16 @@ module Linter
     private
 
     def collect_files
-      ref              = @branch.git_branch_ref
-      diff             = @branch.git_diff
-      files_changed    = diff.deltas.collect { |delta| delta.try(:new_file).try(:[], :path) }.compact
-      files_to_rubocop = filtered_files(files_changed)
+      branch_service   = @branch.git_service
+      diff_service     = branch_service.diff
+      files_to_rubocop = filtered_files(diff_service.new_files)
 
-      (files_to_rubocop + [".rubocop.yml"]).each do |file|
-        blob = diff.owner.blob_at(ref.target.oid, file)
+      (files_to_rubocop + [".rubocop.yml"]).each do |path|
+        blob = branch_service.blob_at(path)
         next unless blob
-        temp_file = File.join(@work_dir, file)
+        temp_file = File.join(@work_dir, path)
         FileUtils.mkdir_p(File.dirname(temp_file))
-        File.write(temp_file, blob.content)
+        File.write(temp_file, blob.content.to_s)
       end
     end
 

--- a/spec/workers/pull_request_monitor/pr_branch_record_spec.rb
+++ b/spec/workers/pull_request_monitor/pr_branch_record_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PullRequestMonitor::PrBranchRecord do
 
       expect(repo).to receive(:git_fetch)
       expect(repo).to receive_message_chain(:branches, :build).with(hash_including(expected)).and_return(pr_branch)
-      expect_any_instance_of(Branch).to receive(:git_merge_base).and_return(pr_branch.last_commit)
+      expect_any_instance_of(Branch).to receive_message_chain(:git_service, :merge_base).and_return(pr_branch.last_commit)
       described_class.create(repo, pr, pr_branch.name)
     end
   end


### PR DESCRIPTION
Add GitService::Branch wrapper to simplify branch methods
Add GitService::Diff wrapper to simplify walking changes
Update Linter::Rubocop to leverage the new GitService classes