### PR TITLE
Don't retry to rubocop an unmergable PR

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -37,6 +37,8 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
     end
 
     write_to_github
+  rescue Rugged::IndexError
+    # Failed to create merge index, no point in trying to lint files for an unmergable PR
   end
 
   def extract_haml_files(diff_details)


### PR DESCRIPTION
Currently, when a rubocop linter tries to run against an unmergable PR, Rugged fails to create an index and raises `Rugged::IndexError`.  That error is raised and Sidekiq puts the job into retry.  We should not retry the job, since a rebase and push from the user should trigger a new rubocop run to be scheduled.