### PR TITLE
Check the bug status before making a comment

### DIFF
--- a/app/workers/commit_monitor_handlers/commit/bugzilla_pr_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit/bugzilla_pr_checker.rb
@@ -41,9 +41,15 @@ module CommitMonitorHandlers
       def add_pr_comment(bug)
         if bug_has_pr_uri_comment?(bug)
           logger.info "Not commenting on bug #{bug.id} due to duplicate comment."
-        else
+          return
+        end
+
+        case bug.status
+        when "NEW", "ASSIGNED", "ON_DEV"
           logger.info "Adding PR comment to bug #{bug.id}."
           bug.add_comment(@branch.github_pr_uri)
+        else
+          logger.info "Not commenting on bug #{bug.id} due to status of #{bug.status}"
         end
       end
 


### PR DESCRIPTION
Sometimes people make PRs with bad rebases that include many commits which should not have been in the PR. This has caused the BugzillaPrChecher to comment on every BZ referenced in those commits with this new PR link.

This change will not completely solve the issue, but will at least prevent the bot from adding comments to BZs which obviously already have fixes (statuses not NEW, ASSIGNED, ON_DEV) and should not be being referenced in PR commits.

Alternative to #193 

@bdunne what do you think?