### PR TITLE
Upgrade awesome_spawn to v1.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'slim'
 gem 'miq_tools_services', "~> 0.1.0", :git => "git://github.com/ManageIQ/miq_tools_services.git", :tag => "v0.1.0"
 gem 'travis', '~>1.7.6'
 
-gem 'awesome_spawn'
+gem 'awesome_spawn', '>= 1.4.1'
 gem 'default_value_for'
 gem 'haml_lint'
 gem 'more_core_extensions', "~> 2.0.0", :require => 'more_core_extensions/all'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     addressable (2.3.8)
     arel (6.0.3)
     ast (2.2.0)
-    awesome_spawn (1.4.0)
+    awesome_spawn (1.4.1)
     backports (3.6.8)
     builder (3.2.2)
     celluloid (0.17.3)
@@ -335,7 +335,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  awesome_spawn
+  awesome_spawn (>= 1.4.1)
   coffee-rails (~> 4.0.0)
   default_value_for
   factory_girl_rails


### PR DESCRIPTION
This version fixes a bug with Pathname objects, which is required for
the bot to work correctly when cloning from GitHub.