### PR TITLE
Extract GemChangesLabeler from DiffFilenameChecker

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/gem_changes_labeler.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/gem_changes_labeler.rb
@@ -1,0 +1,45 @@
+require 'rugged'
+
+class CommitMonitorHandlers::CommitRange::GemChangesLabeler
+  include Sidekiq::Worker
+  sidekiq_options :queue => :miq_bot
+
+  include BranchWorkerMixin
+
+  LABEL = "gem changes".freeze
+
+  def self.handled_branch_modes
+    [:pr]
+  end
+
+  def perform(branch_id, _new_commits)
+    return unless find_branch(branch_id, :pr)
+    return unless verify_branch_enabled
+
+    process_branch
+  end
+
+  private
+
+  def process_branch
+    apply_label if gemfile_changes_in_diff?
+  end
+
+  def gemfile_changes_in_diff?
+    branch.git_service.diff.new_files.any? { |file| gemfile_changes?(file) }
+  rescue Rugged::IndexError
+    # Failed to create merge index, no point in trying
+    return false
+  end
+
+  def gemfile_changes?(file)
+    File.basename(file) == "Gemfile"
+  end
+
+  def apply_label
+    branch.repo.with_github_service do |github|
+      logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
+      github.add_issue_labels(pr_number, LABEL)
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,8 +7,7 @@ github_credentials:
   password:
 commit_monitor:
   bugzilla_product:
-gemfile_checker:
-  pr_contacts: []
+gem_changes_labeler:
   enabled_repos: []
 github_notification_monitor:
   repo_names: []

--- a/spec/workers/commit_monitor_handlers/commit_range/gem_changes_labeler_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/gem_changes_labeler_spec.rb
@@ -1,0 +1,41 @@
+describe CommitMonitorHandlers::CommitRange::GemChangesLabeler do
+  let(:branch)         { create(:pr_branch) }
+  let(:git_service)    { double("GitService", :diff => double("RuggedDiff", :new_files => new_files)) }
+  let(:github_service) { stub_github_service }
+
+  before do
+    stub_sidekiq_logger
+    stub_settings(:gem_changes_labeler, :enabled_repos, [branch.repo.name])
+    expect_any_instance_of(Branch).to receive(:git_service).and_return(git_service)
+  end
+
+  context "when there are Gemfile changes" do
+    let(:new_files) { ["Gemfile", "some/other/file.rb"] }
+
+    it "adds a label to the PR" do
+      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "gem changes")
+
+      described_class.new.perform(branch.id, nil)
+    end
+  end
+
+  context "when there are Gemfile changes to deep Gemfiles" do
+    let(:new_files) { ["gems/pending/Gemfile", "some/other/file.rb"] }
+
+    it "adds a label to the PR" do
+      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "gem changes")
+
+      described_class.new.perform(branch.id, nil)
+    end
+  end
+
+  context "where there are no Gemfile changes" do
+    let(:new_files) { ["some/other/file.rb"] }
+
+    it "does not add a label to the PR" do
+      expect(github_service).to_not receive(:add_issue_labels)
+
+      described_class.new.perform(branch.id, nil)
+    end
+  end
+end


### PR DESCRIPTION
This removes the batch commenting for gem changes.  For those parties
involved, this was not a useful feature anyway, so this simplifies this
down to just labeling.

@bdunne Please review

cc @JPrause @simaishi ... just letting you know I am removing the PR comments about gemfile changes.