### PR TITLE
Add a diff content checker to match Strings, Symbols and Regexps

### DIFF
--- a/app/workers/commit_monitor_handlers/batch/github_pr_commenter.rb
+++ b/app/workers/commit_monitor_handlers/batch/github_pr_commenter.rb
@@ -7,7 +7,7 @@ module CommitMonitorHandlers::Batch
     include BranchWorkerMixin
 
     def self.batch_workers
-      [DiffFilenameChecker]
+      [DiffContentChecker, DiffFilenameChecker]
     end
 
     def perform(batch_job_id, branch_id, _new_commits)

--- a/app/workers/commit_monitor_handlers/batch/github_pr_commenter/diff_content_checker.rb
+++ b/app/workers/commit_monitor_handlers/batch/github_pr_commenter/diff_content_checker.rb
@@ -1,0 +1,45 @@
+module CommitMonitorHandlers::Batch
+  class GithubPrCommenter::DiffContentChecker
+    include Sidekiq::Worker
+    sidekiq_options :queue => :miq_bot
+
+    include BatchEntryWorkerMixin
+    include BranchWorkerMixin
+
+    def perform(batch_entry_id, branch_id, _new_commits)
+      return unless find_batch_entry(batch_entry_id)
+      return unless find_branch(branch_id, :pr)
+      complete_batch_entry({:result => process_lines})
+    end
+
+    private
+
+    def process_lines
+      @offenses = []
+
+      branch.git_service.diff.with_each_line do |line, _parent_hunk, parent_patch|
+        next unless line.addition?
+        check_line(line, parent_patch)
+      end
+
+      @offenses
+    end
+
+    def check_line(line, patch)
+      file_path = patch.delta.new_file[:path]
+      Settings.diff_content_checker.each do |offender, options|
+        next if options.except.try(:any?) { |except| file_path.start_with?(except) }
+
+        regexp = options.type == :regexp ? Regexp.new(offender.to_s) : /\b#{Regexp.escape(offender.to_s)}\b/i
+        add_offense(offender, options, file_path, line) if regexp.match(line.content)
+      end
+    end
+
+    def add_offense(offender, options, file_path, line)
+      line_number = line.new_lineno
+      message     = options.message || "Detected `#{offender}`"
+
+      @offenses << OffenseMessage::Entry.new(options.severity, message, file_path, line_number)
+    end
+  end
+end

--- a/spec/workers/commit_monitor_handlers/batch/github_pr_commenter/diff_content_checker_spec.rb
+++ b/spec/workers/commit_monitor_handlers/batch/github_pr_commenter/diff_content_checker_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe CommitMonitorHandlers::Batch::GithubPrCommenter::DiffContentChecker do
+  let(:batch_entry)        { BatchEntry.create!(:job => BatchJob.create!) }
+  let(:branch)             { create(:pr_branch) }
+  let(:content_1)          { "def a(variable)" }
+  let(:content_2)          { "puts 'hi'" }
+  let(:file_path)          { "tools/abc.rb" }
+  let(:git_service_double) { double("GitService", :diff => diff) }
+
+  let(:diff) do
+    rugged_delta  = double("RuggedDelta", :new_file => {:path => file_path})
+    rugged_line_1 = double("RuggedLine",  :addition? => true, :content => content_1, :new_lineno => 1)
+    rugged_line_2 = double("RuggedLine",  :addition? => true, :content => content_2, :new_lineno => 2)
+    rugged_hunk   = double("RuggedHunk",  :lines => [rugged_line_1, rugged_line_2])
+    rugged_patch  = double("RuggedPatch", :hunks => [rugged_hunk], :delta => rugged_delta)
+    rugged_diff   = double("RuggedDiff",  :patches => [rugged_patch])
+    GitService::Diff.new(rugged_diff)
+  end
+
+  before do
+    stub_sidekiq_logger
+    stub_job_completion
+    expect_any_instance_of(Branch).to receive(:git_service).and_return(git_service_double)
+  end
+
+  context "with offending word" do
+    it "with one offender in the diff" do
+      stub_settings(:diff_content_checker => {"puts" => {:severity => :error}})
+      described_class.new.perform(batch_entry.id, branch.id, nil)
+
+      batch_entry.reload
+      expect(batch_entry.result.length).to eq(1)
+      expect(batch_entry.result.first).to have_attributes(
+        :group   => file_path,
+        :locator => 2,
+        :message => "Detected `puts`"
+      )
+    end
+
+    it "with one offender in the diff of an ignored file" do
+      stub_settings(:diff_content_checker => {"puts" => {:except => ["tools/"], :severity => :error}})
+      described_class.new.perform(batch_entry.id, branch.id, nil)
+
+      batch_entry.reload
+      expect(batch_entry.result.length).to eq(0)
+    end
+
+    context "where the offender is part of another word in the diff" do
+      let(:content_2) { "inputs = variable" }
+
+      it do
+        stub_settings(:diff_content_checker => {"puts" => {:severity => :error}})
+        described_class.new.perform(batch_entry.id, branch.id, nil)
+
+        batch_entry.reload
+        expect(batch_entry.result.length).to eq(0)
+      end
+    end
+  end
+
+  context "with offending regex" do
+    it "with one offender in the diff" do
+      stub_settings(:diff_content_checker => {"^def" => {:severity => :error, :type => :regexp}})
+      described_class.new.perform(batch_entry.id, branch.id, nil)
+
+      batch_entry.reload
+      expect(batch_entry.result.length).to eq(1)
+      expect(batch_entry.result.first).to have_attributes(
+        :group   => file_path,
+        :locator => 1,
+        :message => "Detected `^def`"
+      )
+    end
+  end
+end


### PR DESCRIPTION
This allows the bot to comment when an offender is included in a PR diff.
i.e. Someone leaves a `puts` in their code, however it can be ignored in the tools directory where it is expected.

Fixes #32 

