### PR TITLE
Fix "undefined method html_url for nil"

### DIFF
--- a/app/workers/pull_request_monitor/pr_branch_record.rb
+++ b/app/workers/pull_request_monitor/pr_branch_record.rb
@@ -2,7 +2,8 @@ class PullRequestMonitor
   class PrBranchRecord
     def self.create(repo, pr, branch_name)
       repo.git_fetch
-      commit_uri = File.join(pr.head.repo.html_url, "commit", "$commit")
+      html_url   = pr.head.repo.try(:html_url) || pr.base.repo.html_url
+      commit_uri = File.join(html_url, "commit", "$commit")
       branch     = repo.branches.build(
         :name         => branch_name,
         :commits_list => [],


### PR DESCRIPTION
Sometimes the repo is nil, so we need a different html_url.
i.e. User creates a PR then deletes their fork