### PR TITLE
Ensure 'lib' is eager loaded to avoid missing constants in workers

### DIFF
--- a/Procfile.tmpl
+++ b/Procfile.tmpl
@@ -1,5 +1,5 @@
 thin:            bundle exec rails s -p $PORT
 sidekiq:         bundle exec sidekiq -q miq_bot
 sidekiq_glacial: bundle exec sidekiq -q miq_bot_glacial
-travis_listener: bundle exec rails runner lib/travis_event/listener.rb
+travis_listener: bundle exec rake travis_event_listener:run
 #rails:           tail -f -n 0 log/development.log

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module MiqBot
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.autoload_paths << Rails.root.join("app/workers/concerns")
-    config.autoload_paths << Rails.root.join("lib")
+    config.eager_load_paths << Rails.root.join("app/workers/concerns")
+    config.eager_load_paths << Rails.root.join("lib")
   end
 end

--- a/lib/tasks/travis_event_listener.rake
+++ b/lib/tasks/travis_event_listener.rake
@@ -1,0 +1,6 @@
+namespace :travis_event_listener do
+  desc "Run the Travis Event Listener"
+  task :run => :environment do
+    TravisEvent::Listener.run
+  end
+end

--- a/lib/travis_event/listener.rb
+++ b/lib/travis_event/listener.rb
@@ -12,6 +12,11 @@ module TravisEvent
   class Listener
     ALL_EVENTS = %w(build:created build:started build:finished job:created job:started job:finished)
 
+    def self.run
+      require 'travis'
+      monitor(Settings.travis_event.enabled_repos)
+    end
+
     # repos: ["rails/rails", "manageiq/manageiq"]
     def self.monitor(*slugs)
       Travis.listen(*travis_repos(slugs)) do |stream|
@@ -47,6 +52,3 @@ module TravisEvent
     end
   end
 end
-
-require 'travis'
-TravisEvent::Listener.monitor(Settings.travis_event.enabled_repos)


### PR DESCRIPTION
Make TravisEvent::Listener a library, add a rake task to run it