### PR TITLE
Add sql migration labeler

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/sql_migration_labeler.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/sql_migration_labeler.rb
@@ -1,0 +1,45 @@
+require 'rugged'
+
+class CommitMonitorHandlers::CommitRange::SqlMigrationLabeler
+  include Sidekiq::Worker
+  sidekiq_options :queue => :miq_bot
+
+  include BranchWorkerMixin
+
+  LABEL = "sql migration".freeze
+
+  def self.handled_branch_modes
+    [:pr]
+  end
+
+  def perform(branch_id, _new_commits)
+    return unless find_branch(branch_id, :pr)
+    return unless verify_branch_enabled
+
+    process_branch
+  end
+
+  private
+
+  def process_branch
+    apply_label if migrations_in_diff?
+  end
+
+  def migrations_in_diff?
+    branch.git_service.diff.new_files.any? { |file| migration?(file) }
+  rescue Rugged::IndexError
+    # Failed to create merge index, no point in trying
+    return false
+  end
+
+  def migration?(file)
+    file.include?("db/migrate/") && file.end_with?(".rb") && !file.include?("spec/db/migrate/")
+  end
+
+  def apply_label
+    branch.repo.with_github_service do |github|
+      logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
+      github.add_issue_labels(pr_number, LABEL)
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,5 +11,7 @@ gem_changes_labeler:
   enabled_repos: []
 github_notification_monitor:
   repo_names: []
+sql_migration_labeler:
+  enabled_repos: []
 travis_event:
   enabled_repos: []

--- a/spec/workers/commit_monitor_handlers/commit_range/sql_migration_labeler_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/sql_migration_labeler_spec.rb
@@ -1,0 +1,41 @@
+describe CommitMonitorHandlers::CommitRange::SqlMigrationLabeler do
+  let(:branch)         { create(:pr_branch) }
+  let(:git_service)    { double("GitService", :diff => double("RuggedDiff", :new_files => new_files)) }
+  let(:github_service) { stub_github_service }
+
+  before do
+    stub_sidekiq_logger
+    stub_settings(:sql_migration_labeler => {:enabled_repos => [branch.repo.name]})
+    expect_any_instance_of(Branch).to receive(:git_service).and_return(git_service)
+  end
+
+  context "when there are migrations" do
+    let(:new_files) { ["db/migrate/20160706230546_some_migration.rb", "some/other/file.rb"] }
+
+    it "adds a label to the PR" do
+      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "sql migration")
+
+      described_class.new.perform(branch.id, nil)
+    end
+  end
+
+  context "where there are no migrations" do
+    let(:new_files) { ["some/other/file.rb"] }
+
+    it "does not add a label to the PR" do
+      expect(github_service).to_not receive(:add_issue_labels)
+
+      described_class.new.perform(branch.id, nil)
+    end
+  end
+
+  context "where there are changes to migration specs only" do
+    let(:new_files) { ["spec/db/migrate/20160706230546_some_migration_spec.rb", "some/other/file.rb"] }
+
+    it "does not add a label to the PR" do
+      expect(github_service).to_not receive(:add_issue_labels)
+
+      described_class.new.perform(branch.id, nil)
+    end
+  end
+end


### PR DESCRIPTION
This is mostly copied from the gem changes labeler.  There is a bit of a pattern, but I'm not ready to DRY it up into a separate class until I see a 3rd one ([Rule of three](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)) and all that)

@bdunne  Please review.