### PR TITLE
Add PullRequestMonitorHandlers::MergeTargetTitler

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -62,6 +62,10 @@ class Branch < ActiveRecord::Base
     MiqToolsServices::MiniGit.pr_number(name) if pull_request?
   end
 
+  def pr_title_tags
+    pr_title.to_s.match(/^(?:\s*\[\w+\])+/).to_s.split.map { |s| s[1...-1] }
+  end
+
   def github_pr_uri
     self.class.github_pr_uri(repo.name, pr_number) if pull_request?
   end

--- a/app/workers/concerns/branch_worker_mixin.rb
+++ b/app/workers/concerns/branch_worker_mixin.rb
@@ -1,7 +1,7 @@
 module BranchWorkerMixin
   attr_reader :branch
 
-  delegate :pr_number, :to => :branch
+  delegate :pr_number, :pr_title, :pr_title_tags, :merge_target, :to => :branch
 
   def find_branch(branch_id, required_mode = nil)
     @branch = Branch.where(:id => branch_id).first

--- a/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
+++ b/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
@@ -1,0 +1,39 @@
+class PullRequestMonitorHandlers::MergeTargetTitler
+  include Sidekiq::Worker
+  sidekiq_options :queue => :miq_bot
+
+  include BranchWorkerMixin
+
+  def perform(branch_id)
+    return unless find_branch(branch_id, :pr)
+    return unless verify_branch_enabled
+
+    process_branch
+  end
+
+  private
+
+  def process_branch
+    apply_title if merge_target != "master" && !already_titled?
+  end
+
+  def already_titled?
+    pr_title_tags.map(&:downcase).include?(merge_target.downcase)
+  end
+
+  def apply_title
+    branch.repo.with_github_service do |github|
+      logger.info("Updating PR #{pr_number} with title change for merge target #{merge_target}.")
+      github.pull_requests.update(
+        :user   => github.user,
+        :repo   => github.repo,
+        :number => pr_number,
+        :title  => new_pr_title
+      )
+    end
+  end
+
+  def new_pr_title
+    "[#{merge_target.upcase}] #{pr_title}"
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,8 @@ gem_changes_labeler:
   enabled_repos: []
 github_notification_monitor:
   repo_names: []
+merge_target_titler:
+  enabled_repos: []
 sql_migration_labeler:
   enabled_repos: []
 travis_event:

--- a/spec/factories/branch.rb
+++ b/spec/factories/branch.rb
@@ -11,7 +11,8 @@ FactoryGirl.define do
   end
 
   factory :pr_branch, :parent => :branch do
-    sequence(:name) { |n| "prs/#{n}/head" }
+    sequence(:name)     { |n| "prs/#{n}/head" }
+    sequence(:pr_title) { |n| "PR title #{n}" }
 
     pull_request true
   end

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -110,6 +110,38 @@ describe Branch do
     end
   end
 
+  describe "#pr_title_tags" do
+    it "with a nil pr_title" do
+      branch.pr_title = nil
+      expect(branch.pr_title_tags).to eq []
+    end
+
+    it "with a blank pr_title" do
+      branch.pr_title = ""
+      expect(branch.pr_title_tags).to eq []
+    end
+
+    it "with a pr_title with tags" do
+      branch.pr_title = "[WIP] [foo_bar] This is a PR title"
+      expect(branch.pr_title_tags).to eq ["WIP", "foo_bar"]
+    end
+
+    it "with a pr_title with tags with leading spaces" do
+      branch.pr_title = "  [WIP] [foo_bar] This is a PR title"
+      expect(branch.pr_title_tags).to eq ["WIP", "foo_bar"]
+    end
+
+    it "with a pr_title with tag-like strings not at the start" do
+      branch.pr_title = "This is a [PR] title"
+      expect(branch.pr_title_tags).to eq []
+    end
+
+    it "with a pr_title with both tags at the start and tag-like strings not at the start" do
+      branch.pr_title = "[WIP] [foo_bar] This is a [PR] title"
+      expect(branch.pr_title_tags).to eq ["WIP", "foo_bar"]
+    end
+  end
+
   describe "#github_pr_uri" do
     it "creates correct pr uri" do
       branch.name = "pr/123"

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -95,22 +95,27 @@ describe Repo do
     end
 
     it "creates/updates/deletes PR branches" do
-      pr_branch_to_keep   = create(:pr_branch)
-      pr_branch_to_delete = create(:pr_branch)
+      pr_branch_to_keep   = create(:pr_branch, :repo => repo)
+      pr_branch_to_change = create(:pr_branch, :repo => repo)
+      pr_branch_to_delete = create(:pr_branch, :repo => repo)
       pr_number_to_create = pr_branch_to_delete.pr_number + 1
-
-      repo.update_attributes(:branches => [pr_branch_to_keep, pr_branch_to_delete])
 
       git_service = double("Git service", :merge_base => "123abc")
       expect(repo).to receive(:git_fetch)
-      expect_any_instance_of(Branch).to receive(:git_service).and_return(git_service)
+      allow_any_instance_of(Branch).to receive(:git_service).and_return(git_service)
 
-      repo.synchronize_pr_branches([
+      results = repo.synchronize_pr_branches([
         {
           :number       => pr_branch_to_keep.pr_number,
-          :html_url     => "https://example.com/SomeUser/some_repo",
-          :merge_target => "master",
+          :html_url     => "https://example.com/#{repo.name}",
+          :merge_target => pr_branch_to_keep.merge_target,
           :pr_title     => pr_branch_to_keep.pr_title
+        },
+        {
+          :number       => pr_branch_to_change.pr_number,
+          :html_url     => "https://example.com/#{repo.name}",
+          :merge_target => pr_branch_to_change.merge_target,
+          :pr_title     => "New Title"
         },
         {
           :number       => pr_number_to_create,
@@ -121,12 +126,24 @@ describe Repo do
       ])
 
       branches = repo.branches.order(:id)
-      expect(branches.size).to eq(2)
+      expect(branches.size).to eq(3)
+
+      expect(results).to eq(
+        :unchanged => [pr_branch_to_keep],
+        :updated   => [pr_branch_to_change],
+        :added     => [branches[2]],
+        :deleted   => [pr_branch_to_delete]
+      )
+
       expect(branches[0]).to eq(pr_branch_to_keep)
       expect(branches[0].attributes.except("last_changed_on")).to eq(pr_branch_to_keep.attributes.except("last_changed_on"))
       expect(branches[0].last_changed_on.to_i).to eq(pr_branch_to_keep.last_changed_on.to_i) # Ignore microsecond differences from the database
 
-      expect(branches[1]).to have_attributes(
+      expect(branches[1]).to eq(pr_branch_to_change)
+      expect(branches[1].attributes.except("last_changed_on", "pr_title")).to eq(pr_branch_to_change.attributes.except("last_changed_on", "pr_title"))
+      expect(branches[1].pr_title).to eq("New Title")
+
+      expect(branches[2]).to have_attributes(
         :name         => "prs/#{pr_number_to_create}/head",
         :commits_list => [],
         :commit_uri   => "https://example.com/SomeOtherUser/some_other_repo/commit/$commit",
@@ -140,8 +157,7 @@ describe Repo do
     end
 
     it "handles pruning PR branches" do
-      pr_branch = create(:pr_branch)
-      repo.update_attributes(:branches => [pr_branch])
+      pr_branch = create(:pr_branch, :repo => repo)
 
       expect(repo).to receive(:git_fetch)
 

--- a/spec/workers/pull_request_monitor_handlers/merge_target_titler_spec.rb
+++ b/spec/workers/pull_request_monitor_handlers/merge_target_titler_spec.rb
@@ -1,0 +1,52 @@
+describe PullRequestMonitorHandlers::MergeTargetTitler do
+  let(:branch)         { create(:pr_branch) }
+  let(:github_service) { stub_github_service }
+
+  before do
+    stub_sidekiq_logger
+    stub_settings(:merge_target_titler => {:enabled_repos => [branch.repo.name]})
+  end
+
+  context "when the branch has a non-master merge target" do
+    before do
+      branch.update_attributes!(:merge_target => "darga")
+    end
+
+    it "and not already titled" do
+      expect(github_service).to receive(:user).and_return("SomeUser")
+      expect(github_service).to receive(:repo).and_return("some_repo")
+      expect(github_service).to receive_message_chain(:pull_requests, :update).with(
+        :user   => "SomeUser",
+        :repo   => "some_repo",
+        :number => branch.pr_number,
+        :title  => "[DARGA] #{branch.pr_title}"
+      )
+
+      described_class.new.perform(branch.id)
+    end
+
+    it "and already titled" do
+      branch.update_attributes!(:pr_title => "[DARGA] #{branch.pr_title}")
+
+      expect(github_service).to_not receive(:pull_requests)
+
+      described_class.new.perform(branch.id)
+    end
+
+    it "and already titled, but not at the start" do
+      branch.update_attributes!(:pr_title => "[WIP] [DARGA] #{branch.pr_title}")
+
+      expect(github_service).to_not receive(:pull_requests)
+
+      described_class.new.perform(branch.id)
+    end
+  end
+
+  it "when the branch has a master merge target" do
+    branch.update_attributes!(:merge_target => "master")
+
+      expect(github_service).to_not receive(:pull_requests)
+
+    described_class.new.perform(branch.id)
+  end
+end


### PR DESCRIPTION
which will change a PR title to tag it with the target branch if it is
not master.

Example:
  PR titled "My PR title" is created targeting branch "foo", so PR title
  will be changed to "[FOO] My PR title"

Closes #174

In order to support this new type of handler, this PR adds reacting to PR changes and calling dedicated handlers.

@bdunne Please review.
