### PR TITLE
Add PullRequestMonitorHandlers::WipLabeler

### DIFF
--- a/app/workers/pull_request_monitor_handlers/wip_labeler.rb
+++ b/app/workers/pull_request_monitor_handlers/wip_labeler.rb
@@ -16,7 +16,11 @@ class PullRequestMonitorHandlers::WipLabeler
   private
 
   def process_branch
-    apply_label if wip_in_title?
+    if wip_in_title?
+      apply_label
+    else
+      remove_label
+    end
   end
 
   def wip_in_title?
@@ -27,6 +31,13 @@ class PullRequestMonitorHandlers::WipLabeler
     branch.repo.with_github_service do |github|
       logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
       github.add_issue_labels(pr_number, LABEL)
+    end
+  end
+
+  def remove_label
+    branch.repo.with_github_service do |github|
+      logger.info("Updating PR #{pr_number} without label #{LABEL.inspect}.")
+      github.remove_issue_labels(pr_number, LABEL)
     end
   end
 end

--- a/app/workers/pull_request_monitor_handlers/wip_labeler.rb
+++ b/app/workers/pull_request_monitor_handlers/wip_labeler.rb
@@ -1,0 +1,32 @@
+class PullRequestMonitorHandlers::WipLabeler
+  include Sidekiq::Worker
+  sidekiq_options :queue => :miq_bot
+
+  include BranchWorkerMixin
+
+  LABEL = "wip".freeze
+
+  def perform(branch_id)
+    return unless find_branch(branch_id, :pr)
+    return unless verify_branch_enabled
+
+    process_branch
+  end
+
+  private
+
+  def process_branch
+    apply_label if wip_in_title?
+  end
+
+  def wip_in_title?
+    pr_title_tags.map(&:downcase).include?(LABEL)
+  end
+
+  def apply_label
+    branch.repo.with_github_service do |github|
+      logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
+      github.add_issue_labels(pr_number, LABEL)
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,3 +28,5 @@ sql_migration_labeler:
   enabled_repos: []
 travis_event:
   enabled_repos: []
+wip_labeler:
+  enabled_repos: []

--- a/lib/github_service.rb
+++ b/lib/github_service.rb
@@ -87,4 +87,14 @@ class GithubService
       issues.labels.add(user, repo, issue_id, label)
     end
   end
+
+  # Removes the labels specified, but only if they are on the issue.
+  def remove_issue_labels(issue_id, labels)
+    old_labels = issue_label_names(issue_id)
+
+    Array(labels).each do |label|
+      next unless old_labels.include?(label)
+      issues.label.remove(user, repo, issue_id, :label_name => label)
+    end
+  end
 end

--- a/spec/models/git_hub_api/issue_spec.rb
+++ b/spec/models/git_hub_api/issue_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+RSpec.describe GitHubApi::Issue do
+  describe "#add_labels" do
+    it "updates the title with [WIP] when adding wip label" do
+      octokit_issue = spy("Octokit::Issue", :title => "War and Peace")
+      repo = spy("GitHubApi::Repo")
+      label = instance_double("GitHubApi::Label", :text => "wip")
+      issue = described_class.new(octokit_issue, repo)
+      issue.instance_variable_set(:@applied_labels, "wip" => label)
+
+      expect(GitHubApi)
+        .to receive(:execute)
+        .with(anything, :add_labels_to_an_issue, anything, anything, ["wip"])
+        .once
+
+      expect(GitHubApi)
+        .to receive(:execute)
+        .with(anything, :update_issue, anything, anything, :title => "[WIP] War and Peace")
+        .once
+
+      issue.add_labels([label])
+    end
+  end
+
+  describe "#remove_label" do
+    it "updates the title without [WIP] when removing wip label" do
+      octokit_issue = spy("Octokit::Issue", :title => "[WIP] War and Peace")
+      repo = spy("GitHubApi::Repo")
+      issue = described_class.new(octokit_issue, repo)
+      issue.instance_variable_set(:@applied_labels, {})
+
+      expect(GitHubApi)
+        .to receive(:execute)
+        .with(anything, :remove_label, anything, anything, "wip")
+        .once
+
+      expect(GitHubApi)
+        .to receive(:execute)
+        .with(anything, :update_issue, anything, anything, :title => "War and Peace")
+        .once
+
+      issue.remove_label("wip")
+    end
+  end
+end

--- a/spec/workers/pull_request_monitor_handlers/wip_labeler_spec.rb
+++ b/spec/workers/pull_request_monitor_handlers/wip_labeler_spec.rb
@@ -7,17 +7,21 @@ describe PullRequestMonitorHandlers::WipLabeler do
     stub_settings(:wip_labeler => {:enabled_repos => [branch.repo.name]})
   end
 
-  it "when the PR title does not have [WIP]" do
-    expect(github_service).to_not receive(:add_issue_labels)
+  context "when the PR title does not have [WIP]" do
+    it "removes the wip label if it exists" do
+      expect(github_service).to receive(:remove_issue_labels).with(branch.pr_number, "wip")
 
-    described_class.new.perform(branch.id)
+      described_class.new.perform(branch.id)
+    end
   end
 
-  it "when the PR title has [WIP]" do
-    branch.update_attributes(:pr_title => "[WIP] #{branch.pr_title}")
+  context "when the PR title has [WIP]" do
+    it "adds the wip label if it does not exist" do
+      branch.update_attributes(:pr_title => "[WIP] #{branch.pr_title}")
 
-    expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "wip")
+      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "wip")
 
-    described_class.new.perform(branch.id)
+      described_class.new.perform(branch.id)
+    end
   end
 end

--- a/spec/workers/pull_request_monitor_handlers/wip_labeler_spec.rb
+++ b/spec/workers/pull_request_monitor_handlers/wip_labeler_spec.rb
@@ -1,0 +1,23 @@
+describe PullRequestMonitorHandlers::WipLabeler do
+  let(:branch)         { create(:pr_branch) }
+  let(:github_service) { stub_github_service }
+
+  before do
+    stub_sidekiq_logger
+    stub_settings(:wip_labeler => {:enabled_repos => [branch.repo.name]})
+  end
+
+  it "when the PR title does not have [WIP]" do
+    expect(github_service).to_not receive(:add_issue_labels)
+
+    described_class.new.perform(branch.id)
+  end
+
+  it "when the PR title has [WIP]" do
+    branch.update_attributes(:pr_title => "[WIP] #{branch.pr_title}")
+
+    expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "wip")
+
+    described_class.new.perform(branch.id)
+  end
+end


### PR DESCRIPTION
This is the first part of supporting automatic WIP labeling and handles
a user changing the title to have [WIP].  Not yet handled is when a user
removes [WIP], nor if they manually add the label with an miq-bot command

Issue #34

~~Built on top of #219 since that one has the basis for PR handlers.  See only the last commit.~~ #219 is merged and this has been rebased.

@bdunne Please review
