### PR TITLE
Add the .rubocop_base.yml file to the linter config files list

### DIFF
--- a/lib/linter/rubocop.rb
+++ b/lib/linter/rubocop.rb
@@ -5,7 +5,7 @@ module Linter
     private
 
     def config_files
-      [".rubocop.yml"]
+      [".rubocop_base.yml", ".rubocop.yml"]
     end
 
     def linter_executable


### PR DESCRIPTION
This was added in https://github.com/ManageIQ/manageiq/pull/11750 so that we could avoid inheriting from a remote repo as that is not supported by code climate.

@bdunne @jrafanie please review