### PR TITLE
Removed needless requires, removes warnings

### DIFF
--- a/app/workers/commit_monitor_handlers/commit/bugzilla_commenter.rb
+++ b/app/workers/commit_monitor_handlers/commit/bugzilla_commenter.rb
@@ -1,5 +1,3 @@
-require 'bugzilla_worker_common'
-
 module CommitMonitorHandlers
   module Commit
     class BugzillaCommenter

--- a/app/workers/commit_monitor_handlers/commit/bugzilla_pr_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit/bugzilla_pr_checker.rb
@@ -1,5 +1,3 @@
-require 'bugzilla_worker_common'
-
 module CommitMonitorHandlers
   module Commit
     class BugzillaPrChecker


### PR DESCRIPTION
These are auto loaded by Rails and the re-require causes warnings of
redefining the BugNotFoundError therein when you load the bot.