### PR TITLE
Prevent the use of git scheme when cloning from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ underscores replaced with hyphens.
    ```
 
 6. Create/fork a test repository and add it to the database (replace `miq-test/sandbox` with your test
-   repository below):
+   repository below). Note that the url provided must use the http or https scheme:
    ```
-   bundle exec rails runner 'Repo.create_from_github!("miq-test/sandbox", "git@github.com:miq-test/sandbox.git")'
+   bundle exec rails runner 'Repo.create_from_github!("miq-test/sandbox", "https://github.com/miq-test/sandbox.git")'
    ```
 
 7. Create a custom Procfile for development. Any changes you make to this file

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -6,6 +6,7 @@ class Repo < ActiveRecord::Base
   validates :name, :presence => true, :uniqueness => true
 
   def self.create_from_github!(name, url)
+    raise ArgumentError, "do not use git scheme for url, use http or https instead" if url =~ /^git/
     create_and_clone!(name, url, Branch.github_commit_uri(name))
   end
 

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -3,6 +3,29 @@ require 'spec_helper'
 describe Repo do
   let(:repo) { build(:repo) }
 
+  describe ".create_from_github!" do
+    context "when a https url scheme is used" do
+      before(:each) do
+        allow(MiqToolsServices::MiniGit).to receive(:clone)
+        allow(MiqToolsServices::MiniGit).to receive(:call) { "last_commit" }
+      end
+
+      it "does not raise an error" do
+        expect do
+          described_class.create_from_github!("foo/bar", "https://github.com/foo/bar.git")
+        end.to_not raise_error
+      end
+    end
+
+    context "when a git url scheme is used" do
+      it "raises an ArgumentError" do
+        expect do
+          described_class.create_from_github!("foo/bar", "git@github.com:foo/bar.git")
+        end.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe "#name_parts" do
     it "without an upstream user" do
       repo.name = "foo"


### PR DESCRIPTION
If the git scheme is used when cloning from GitHub the
`PullRequestMonitor` will fail with a `Rugged::NetworkError`. This
change updates the README to advise using the correct url as well as
providing better defect localization.