### PR TITLE
Use GitHub search API to construct backport requests view

### DIFF
--- a/app/controllers/backport_requests_controller.rb
+++ b/app/controllers/backport_requests_controller.rb
@@ -1,0 +1,6 @@
+class BackportRequestsController < ApplicationController
+  def index
+    @target_branch = params[:target_branch]
+    @backport_requests = Backporting.search_for_backport_requests(@target_branch)
+  end
+end

--- a/app/views/backport_requests/index.html.erb
+++ b/app/views/backport_requests/index.html.erb
@@ -1,0 +1,25 @@
+<div class="panel panel-default">
+	<div class="panel-heading">
+    <h3 class="panel-title">Backport Requests To <%= @target_branch.capitalize %></h3>
+	</div>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th class="text-center">#</th>
+        <th>Repository</th>
+        <th>Title</th>
+        <th>Merged</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @backport_requests.each do |backport_request| %>
+        <tr>
+          <td><%= link_to(backport_request.number, backport_request.html_url, :target => '_blank') %></td>
+          <td><%= backport_request.repository_url.split('/').last %></td>
+          <td><%= backport_request.title %></td>
+          <td><%= time_ago_in_words_with_nil_check(backport_request.closed_at) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,16 +1,20 @@
 <div class="navbar navbar-default">
 	<div class="navbar-header">
-		<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-			<span class="sr-only">Toggle navigation</span>
-			<span class="icon-bar"></span>
-			<span class="icon-bar"></span>
-			<span class="icon-bar"></span>
-		</button>
 		<a class="navbar-brand" href="/">MIQ Bot</a>
 	</div>
 	<div class="navbar-collapse collapse">
 		<ul class="nav navbar-nav navbar-right">
 			<li><%= link_to("Sidekiq", "/sidekiq") %></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">
+          Backport Requests <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+          <% Backporting::TARGET_BRANCHES.each do |branch| %>
+            <li><a href="backport_requests?target_branch=<%= branch %>"><%= branch.capitalize %></a></li>
+          <% end %>
+        </ul>
+      </li>
 		</ul>
 	</div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ MiqBot::Application.routes.draw do
   # You can have the root of your site routed with "root"
   root 'main#index'
 
+  get '/backport_requests' => 'backport_requests#index'
+
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 

--- a/lib/backporting.rb
+++ b/lib/backporting.rb
@@ -1,0 +1,15 @@
+module Backporting
+  TARGET_BRANCHES = %w(darga euwe).freeze
+
+  # Backport requests are merged pull requests from the ManageIQ repos marked by
+  # labels such as 'darga/yes'
+  def self.search_for_backport_requests(branch)
+    MiqToolsServices::Github.call({}) do |github|
+      github.search.issues(
+        :q     => "user:ManageIQ is:merged label:#{branch}/yes",
+        :sort  => "updated",
+        :order => "desc"
+      )
+    end.items
+  end
+end


### PR DESCRIPTION
Using the GitHub search API, every pending backport for a target branch
name can be identified with a single API request. This change adds a new
dashboard view for backport requests per branch.

The request to GitHub when the page is viewed so there is a small chance
of bumping into rate limits. The search API has it's own rate limits
(30/minute), so it should not affect existing bot behavior and should
not be reached under normal circumstances.

<img width="1166" alt="screen shot 2016-10-24 at 3 36 08 pm" src="https://cloud.githubusercontent.com/assets/6842753/19660917/a58d3b74-99ff-11e6-9c0a-60a0b1daad5e.png">
