### PR TITLE
Fix issue where invalid assignees were being sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ underscores replaced with hyphens.
   Multiple labels should be comma-separated.  e.g.
   `@miq-bot remove_label label1, label2, label3`
 - `assign`: Assign the issue to the specified user.  The leading `@` for the
-  user is optional.  The user must be in the organization, and must have
-  publicized their membership in order to be assigned.  e.g.
+  user is optional.  The user must be in the Assignees list.  e.g.
   `@miq-bot assign @user`
 - `set_milestone`: Set the specified milestone on the issue. Do not wrap the
   milestone in quotes.  e.g. `@miq-bot set_milestone Sprint 27`

--- a/app/models/git_hub_api/organization.rb
+++ b/app/models/git_hub_api/organization.rb
@@ -7,25 +7,6 @@ module GitHubApi
       @name = octokit_org.login
     end
 
-    def self.members_cache
-      @members_cache ||= {}
-    end
-
-    def members
-      self.class.members_cache[name] ||= begin
-        org_members = GitHubApi.execute(@client, :organization_members, @name)
-        Set.new.tap { |set| org_members.each { |m| set.add(m["login"]) } }
-      end
-    end
-
-    def member?(user)
-      members.include?(user)
-    end
-
-    def refresh_members
-      self.class.members_cache.delete(name)
-    end
-
     def get_repository(repo_name)
       fq_repo_name = "#{@name}/#{repo_name}"
       octokit_repo = GitHubApi.execute(@client, :repo, fq_repo_name)

--- a/app/models/git_hub_api/repo.rb
+++ b/app/models/git_hub_api/repo.rb
@@ -24,7 +24,7 @@ module GitHubApi
     def labels
       self.class.labels_cache[fq_repo_name] ||= begin
         repo_labels = GitHubApi.execute(@client, :labels, @fq_repo_name)
-        Set.new.tap { |set| repo_labels.each { |l| set.add(l.name) } }
+        Set.new(repo_labels.collect(&:name))
       end
     end
 
@@ -53,6 +53,25 @@ module GitHubApi
 
     def refresh_milestones
       self.class.milestones_cache.delete(fq_repo_name)
+    end
+
+    def self.assignees_cache
+      @assignees_cache ||= {}
+    end
+
+    def assignees
+      self.class.assignees_cache[fq_repo_name] ||= begin
+        repo_assignees = GitHubApi.execute(@client, :repo_assignees, @fq_repo_name)
+        Set.new(repo_assignees.collect(&:login))
+      end
+    end
+
+    def valid_assignee?(user)
+      assignees.include?(user)
+    end
+
+    def refresh_assignees
+      self.class.assignees_cache.delete(fq_repo_name)
     end
   end
 end


### PR DESCRIPTION
Previously, we would filter against the organization members, but this
is invalid.  It just *happened* to work in the main repo, because
everyone was an assignee in the main repo, but when moving out to a
split repo, this is no longer valid.

Additionally, organization member caching was only implemented for this
purpose, so instead this is removed in favor of per-repo caching of
assignees.  Also, the org parameter to the GithubNotificationMonitor was
only there for the org member caching, so it too is removed.

@bdunne Please review.