### PR TITLE
Remove and clarify the HTTPS git URL restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ underscores replaced with hyphens.
    ```
 
 6. Create/fork a test repository and add it to the database (replace `miq-test/sandbox` with your test
-   repository below). Note that the url provided must use the http or https scheme:
+   repository below).  Note that the bot account you are using must have SSH keys defined correctly
+   if you plan to use an SSH based URL, otherwise you should use an HTTPS based URL.
    ```
    bundle exec rails runner 'Repo.create_from_github!("miq-test/sandbox", "https://github.com/miq-test/sandbox.git")'
    ```

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -6,7 +6,6 @@ class Repo < ActiveRecord::Base
   validates :name, :presence => true, :uniqueness => true
 
   def self.create_from_github!(name, url)
-    raise ArgumentError, "do not use git scheme for url, use http or https instead" if url =~ /^git/
     create_and_clone!(name, url, Branch.github_commit_uri(name))
   end
 


### PR DESCRIPTION
@bdunne Please review.

This was added because it was assumed that SSH URLs wouldn't work, but they work fine as long as the bot account has the keys in place.