### PR TITLE
Move up the ensure_prs_refs call to the creation of the repo

### DIFF
--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -7,7 +7,8 @@ describe Repo do
     expected_repo_dir = described_class::BASE_PATH.join("foo/bar")
 
     expect(MiqToolsServices::MiniGit).to receive(:clone)
-    expect(MiqToolsServices::MiniGit).to receive(:call).with(expected_repo_dir).and_return("0123abcd")
+    expect(MiqToolsServices::MiniGit).to receive(:call).with(expected_repo_dir).and_return("0123abcd") # current_ref
+    expect(MiqToolsServices::MiniGit).to receive(:call).with(expected_repo_dir).and_return(nil)        # ensure_prs_refs
 
     described_class.create_from_github!("foo/bar", "https://github.com/foo/bar.git")
 

--- a/spec/support/miq_tools_services_helper.rb
+++ b/spec/support/miq_tools_services_helper.rb
@@ -1,6 +1,5 @@
 def stub_git_service
   double("MiniGit service").tap do |git|
-    allow(git).to receive(:ensure_prs_refs)
     allow(git).to receive(:fetch).with("--all")
     allow(MiqToolsServices::MiniGit).to receive(:call).and_yield(git)
   end


### PR DESCRIPTION
This prevents it from running on every single call to with_git_service

@bdunne Please review.