### PR TITLE
Add PrivotalPrChecker to look for Pivotal stories in commits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,8 @@ gem 'sinatra', require: false
 gem 'slim'
 
 gem 'miq_tools_services', '~> 0.1.0', :git => 'https://github.com/ManageIQ/miq_tools_services.git', :tag => 'v0.1.0'
-gem 'travis',             '~>1.7.6'
+gem 'travis',             '~> 1.7.6'
+gem 'tracker_api',        '~> 1.6'
 
 gem 'awesome_spawn',        '>= 1.4.1'
 gem 'default_value_for'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The ManageIQ bot is the ManageIQ team's helper to automate various developer pro
   - Detection of Red Hat Bugzilla URLs in commit messages
     - in pull request branches, setting the BZ to ON_DEV if not already set.
     - in regular branches, writing the commit details to the BZ ticket.
+  - Detection of Pivotal Tracker stories in commit messages
+    - in pull request branches, adding a comment to the Pivotal story.
   - Detection of changes to a product's Gemfile, and setting a label.
 - GitHub pull request monitoring
   - Label and comment on a PR when it becomes unmergeable.

--- a/app/workers/commit_monitor_handlers/commit/pivotal_pr_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit/pivotal_pr_checker.rb
@@ -1,0 +1,45 @@
+module CommitMonitorHandlers
+  module Commit
+    class PivotalPrChecker
+      include Sidekiq::Worker
+      sidekiq_options :queue => :miq_bot
+
+      include BranchWorkerMixin
+
+      def self.handled_branch_modes
+        [:pr]
+      end
+
+      attr_reader :commit, :message
+
+      def perform(branch_id, commit, commit_details)
+        return unless find_branch(branch_id, :pr)
+        return unless verify_branch_enabled
+
+        @commit  = commit
+        @message = commit_details["message"]
+
+        PivotalService.ids_in_git_commit_message(message).each do |story_id|
+          update_pivotal_story(story_id)
+        end
+      end
+
+      private
+
+      def update_pivotal_story(story_id)
+        PivotalService.call do |client|
+          story = client.story(story_id)
+          story.create_comment(:text => branch.github_pr_uri) unless already_linked?(story)
+        end
+      end
+
+      def already_linked?(story)
+        github_pr_uri?(story.description) || story.comments.any? { |comment| github_pr_uri?(comment.text) }
+      end
+
+      def github_pr_uri?(text)
+        text.include?(branch.github_pr_uri)
+      end
+    end
+  end
+end

--- a/config/initializers/miq_tools_services_initializer.rb
+++ b/config/initializers/miq_tools_services_initializer.rb
@@ -1,4 +1,6 @@
 unless Rails.env.test?
   MiqToolsServices::Bugzilla.credentials = Settings.bugzilla_credentials
   MiqToolsServices::Github.credentials   = Settings.github_credentials
+
+  PivotalService.credentials = Settings.pivotal_credentials
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,9 @@ bugzilla_credentials:
 github_credentials:
   username:
   password:
+pivotal_credentials:
+  token:
+
 commit_monitor:
   bugzilla_product:
 diff_content_checker: {}
@@ -13,6 +16,8 @@ gem_changes_labeler:
 github_notification_monitor:
   repo_names: []
 merge_target_titler:
+  enabled_repos: []
+pivotal_pr_checker:
   enabled_repos: []
 sql_migration_labeler:
   enabled_repos: []

--- a/lib/pivotal_service.rb
+++ b/lib/pivotal_service.rb
@@ -1,0 +1,29 @@
+class PivotalService
+  include ServiceMixin
+
+  # https://www.pivotaltracker.com/story/show/<story_id>
+  # https://pivotaltracker.com/story/show/<story_id>
+  # https://www.pivotaltracker.com/n/projects/<project_id>/stories/<story_id>
+  # https://pivotaltracker.com/n/projects/<project_id>/stories/<story_id>
+  URL_REGEX = %r{https://(?:www\.)?pivotaltracker\.com/(?:story/show/(?<id>\d+)|n/projects/\d+/stories/(?<id>\d+))}
+
+  def initialize
+    service # initialize the service
+  end
+
+  def service
+    @service ||= begin
+      require 'tracker_api'
+      TrackerApi::Client.new(credentials.to_h.symbolize_keys)
+    end
+  end
+
+  def self.ids_in_git_commit_message(message)
+    ids = []
+    message.each_line.collect do |line|
+      match = URL_REGEX.match(line)
+      ids << match[:id].to_i if match
+    end
+    ids.uniq
+  end
+end

--- a/lib/service_mixin.rb
+++ b/lib/service_mixin.rb
@@ -1,0 +1,37 @@
+require "active_support/core_ext/module/delegation"
+require "active_support/concern"
+
+module ServiceMixin
+  extend ActiveSupport::Concern
+
+  included do
+    # Hide new in favor of using .call with block for consistency with No
+    private_class_method :new
+
+    class << self
+      attr_accessor :credentials
+    end
+    delegate :credentials, :to => self
+  end
+
+  module ClassMethods
+    def call(*options)
+      raise "no block given" unless block_given?
+      yield new(*options)
+    end
+  end
+
+  private
+
+  def delegate_to_service(method_name, *args)
+    service.send(method_name, *args)
+  end
+
+  def method_missing(method_name, *args) # rubocop:disable Style/MethodMissing
+    delegate_to_service(method_name, *args)
+  end
+
+  def respond_to_missing?(*args)
+    service.respond_to?(*args)
+  end
+end

--- a/spec/lib/pivotal_service_spec.rb
+++ b/spec/lib/pivotal_service_spec.rb
@@ -1,0 +1,45 @@
+# rubocop:disable Style/NumericLiterals
+
+describe PivotalService do
+  describe ".ids_in_git_commit_message" do
+    it "with direct story url" do
+      url = "https://www.pivotaltracker.com/story/show/137739189"
+      expect(described_class.ids_in_git_commit_message(url)).to eq [137739189]
+    end
+
+    it "with abbreviated direct story url" do
+      url = "https://pivotaltracker.com/story/show/137739189"
+      expect(described_class.ids_in_git_commit_message(url)).to eq [137739189]
+    end
+
+    it "with project's story url" do
+      url = "https://www.pivotaltracker.com/n/projects/1953721/stories/137739189"
+      expect(described_class.ids_in_git_commit_message(url)).to eq [137739189]
+    end
+
+    it "with abbreviated project's story url" do
+      url = "https://pivotaltracker.com/n/projects/1953721/stories/137739189"
+      expect(described_class.ids_in_git_commit_message(url)).to eq [137739189]
+    end
+
+    it "with multiple urls" do
+      message = <<-EOMSG
+Some commit message
+
+https://www.pivotaltracker.com/story/show/137739189
+https://www.pivotaltracker.com/story/show/137739190
+EOMSG
+      expect(described_class.ids_in_git_commit_message(message)).to eq [137739189, 137739190]
+    end
+
+    it "with duplicate urls" do
+      message = <<-EOMSG
+Some commit message
+
+https://www.pivotaltracker.com/story/show/137739189
+https://www.pivotaltracker.com/story/show/137739189
+EOMSG
+      expect(described_class.ids_in_git_commit_message(message)).to eq [137739189]
+    end
+  end
+end


### PR DESCRIPTION
Accepted URL formats are:
- `https://www.pivotaltracker.com/story/show/<story_id>`
- `https://pivotaltracker.com/story/show/<story_id>`
- `https://www.pivotaltracker.com/n/projects/1953721/stories/<story_id>`
- `https://pivotaltracker.com/n/projects/1953721/stories/<story_id>`

Part of https://github.com/ManageIQ/miq_bot/issues/241

@bdunne Please review