### PR TITLE
Use previous datapoints in usage aggregation query

### DIFF
--- a/lib/github_usage_tracker.rb
+++ b/lib/github_usage_tracker.rb
@@ -20,6 +20,7 @@ class GithubUsageTracker
       WHERE time > '#{from_time.rfc3339}'
       AND time <= '#{current_time.rfc3339}'
       GROUP BY time(1m)
+      fill(previous)
     eos
 
     influxdb.query(query)


### PR DESCRIPTION
When there's no github requests in a 60 second timeframe, no data is
added to Influx. Therefore, when aggregating data for display use
the previous datapoints instead of null for that interval.

Fixes:

![](http://screenshots.chrisarcand.com/permrdhly.jpg)