### PR TITLE
Fix limit diff from bot db

### DIFF
--- a/db/migrate/20170127173128_fix_limit_in_schema.rb
+++ b/db/migrate/20170127173128_fix_limit_in_schema.rb
@@ -1,0 +1,11 @@
+class FixLimitInSchema < ActiveRecord::Migration
+  def change
+    change_column :batch_entries, :state, :string, :limit => 255
+    change_column :batch_jobs, :on_complete_class, :string, :limit => 255
+    change_column :batch_jobs, :state, :string, :limit => 255
+    change_column :branches, :name, :string, :limit => 255
+    change_column :branches, :commit_uri, :string, :limit => 255
+    change_column :branches, :last_commit, :string, :limit => 255
+    change_column :repos, :name, :string, :limit => 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160713200646) do
+ActiveRecord::Schema.define(version: 20170127173128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "batch_entries", force: :cascade do |t|
     t.integer "batch_job_id"
-    t.string  "state"
+    t.string  "state",        limit: 255
     t.text    "result"
   end
 
@@ -28,15 +28,15 @@ ActiveRecord::Schema.define(version: 20160713200646) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "expires_at"
-    t.string   "on_complete_class"
+    t.string   "on_complete_class", limit: 255
     t.text     "on_complete_args"
-    t.string   "state"
+    t.string   "state",             limit: 255
   end
 
   create_table "branches", force: :cascade do |t|
-    t.string   "name"
-    t.string   "commit_uri"
-    t.string   "last_commit"
+    t.string   "name",            limit: 255
+    t.string   "commit_uri",      limit: 255
+    t.string   "last_commit",     limit: 255
     t.integer  "repo_id"
     t.boolean  "pull_request"
     t.datetime "last_checked_on"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 20160713200646) do
   end
 
   create_table "repos", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
The bot is currently getting changes in its git stage because the db was
created from a previous era where Rails put limits in its columns
without you specifying. This migration is a no op in the bot's
perspectice but adds these limits for development environments so the
schema is exactly the same as what the bot currently uses.