### PR TITLE
Fix incorrect SHA recording

### DIFF
--- a/lib/miq_bot.rb
+++ b/lib/miq_bot.rb
@@ -4,6 +4,6 @@ module MiqBot
   end
 
   def self.current_bot_sha
-    @current_git_sha ||= `git rev-parse --short --verify HEAD`.strip
+    @current_git_sha ||= `GIT_DIR=#{Rails.root.join('.git')} git rev-parse --short --verify HEAD`.strip
   end
 end


### PR DESCRIPTION
Due to minigit changing GIT_DIR, the bot was recording SHAs from random
repos.

In console:
```ruby
# export GIT_DIR=asdf
> `git rev-parse --short --verify HEAD`
fatal: Not a git repository: 'asdf'
=> ""
> MiqBot.current_bot_sha
=> "cf4e9fe"
> `git rev-parse --short --verify HEAD`
fatal: Not a git repository: 'asdf'
=> ""
```