### PR TITLE
Measure Github request URIs

### DIFF
--- a/app/models/git_hub_api.rb
+++ b/app/models/git_hub_api.rb
@@ -1,9 +1,9 @@
 require 'benchmark'
 
 module GitHubApi
-  def self.connect(username, password)
+  def self.connect
     @user = GitHubApi::User.new
-    @user.client ||= Octokit::Client.new(:login => username, :password => password, :auto_paginate => true)
+    @user.client ||= Octokit::Client.new
 
     return @user
   end

--- a/app/models/git_hub_api.rb
+++ b/app/models/git_hub_api.rb
@@ -16,9 +16,6 @@ module GitHubApi
     limit_after = client.rate_limit.remaining
     logger.info("Executed #{cmd} #{args.inspect}...api calls remaining #{limit_after} " \
                 "(in #{"%0.3f" % t}s using #{limit_before - limit_after} calls)")
-    GithubUsageTracker.record_datapoint(:requests_remaining => limit_after,
-                                        :uri                => client.last_response.data.url,
-                                        :timestamp          => client.last_response.time)
     val
   rescue => err
     logger.error("Executed #{cmd} #{args.inspect}...Failed in #{"%0.3f" % t}s")

--- a/app/models/git_hub_api.rb
+++ b/app/models/git_hub_api.rb
@@ -17,6 +17,7 @@ module GitHubApi
     logger.info("Executed #{cmd} #{args.inspect}...api calls remaining #{limit_after} " \
                 "(in #{"%0.3f" % t}s using #{limit_before - limit_after} calls)")
     GithubUsageTracker.record_datapoint(:requests_remaining => limit_after,
+                                        :uri                => client.last_response.data.url,
                                         :timestamp          => client.last_response.time)
     val
   rescue => err

--- a/app/models/github_notification_monitor.rb
+++ b/app/models/github_notification_monitor.rb
@@ -14,15 +14,11 @@ class GithubNotificationMonitor
   ).freeze
 
   def self.build(organization_name, repo_name)
-    username     = Settings.github_credentials.username
-    password     = Settings.github_credentials.password
-    raise "no GitHub credentials defined" if username.nil? || password.nil?
-
     fq_repo_name = "#{organization_name}/#{repo_name}"
-    user         = GitHubApi.connect(username, password)
+    user         = GitHubApi.connect
     org          = user.find_organization(organization_name)
     repo         = org.get_repository(repo_name)
-    new(repo, username, fq_repo_name)
+    new(repo, Octokit.login, fq_repo_name)
   end
 
   def initialize(repo, username, fq_repo_name)

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -2,4 +2,8 @@ Octokit.configure do |c|
   c.login    = Settings.github_credentials.username
   c.password = Settings.github_credentials.password
   c.auto_paginate = true
+
+  rack_builder = Octokit::Default.middleware
+  rack_builder.use GithubService::Response::RatelimitLogger
+  c.middleware = rack_builder
 end

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,0 +1,5 @@
+Octokit.configure do |c|
+  c.login    = Settings.github_credentials.username
+  c.password = Settings.github_credentials.password
+  c.auto_paginate = true
+end

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -4,6 +4,6 @@ Octokit.configure do |c|
   c.auto_paginate = true
 
   rack_builder = Octokit::Default.middleware
-  rack_builder.use GithubService::Response::RatelimitLogger
+  rack_builder.use(GithubService::Response::RatelimitLogger)
   c.middleware = rack_builder
 end

--- a/lib/github_service/response/ratelimit_logger.rb
+++ b/lib/github_service/response/ratelimit_logger.rb
@@ -18,6 +18,7 @@ class GithubService
         logger.info { "Executed #{env.method.to_s.upcase} #{env.url}...api calls remaining #{api_calls_remaining}" }
         GithubUsageTracker.record_datapoint(
           :requests_remaining => api_calls_remaining,
+          :uri                => env.url.request_uri,
           :timestamp          => DateTime.parse(env.response_headers["date"])
         )
       end

--- a/lib/github_usage_tracker.rb
+++ b/lib/github_usage_tracker.rb
@@ -11,7 +11,7 @@ class GithubUsageTracker
     influxdb.write_point(
       'github_api_request',
       { :tags      => { :bot_version        => MiqBot.version },
-        :values    => { :requests_remaining => requests_remaining.to_i, uri: request_uri },
+        :values    => { :requests_remaining => requests_remaining.to_i, :uri => request_uri },
         :timestamp => timestamp ? timestamp.to_i : Time.now.to_i }
     )
   rescue => e

--- a/lib/github_usage_tracker.rb
+++ b/lib/github_usage_tracker.rb
@@ -1,17 +1,21 @@
+require 'uri'
+
 class GithubUsageTracker
   def self.record_datapoint(**args)
     new.record_datapoint(args)
   end
 
-  def record_datapoint(requests_remaining:, timestamp: nil)
+  def record_datapoint(requests_remaining:, uri:, timestamp: nil)
+    request_uri = URI.parse(uri).path.chomp("/")
+
     influxdb.write_point(
-      'rate_limit',
+      'github_api_request',
       { :tags      => { :bot_version        => MiqBot.version },
-        :values    => { :requests_remaining => requests_remaining.to_i },
+        :values    => { :requests_remaining => requests_remaining.to_i, uri: request_uri },
         :timestamp => timestamp ? timestamp.to_i : Time.now.to_i }
     )
   rescue => e
-    logger.info("#{e.name}: #{e.message}")
+    Rails.logger.info("#{e.class}: #{e.message}")
   end
 
   private

--- a/spec/lib/github_usage_tracker_spec.rb
+++ b/spec/lib/github_usage_tracker_spec.rb
@@ -1,0 +1,56 @@
+describe GithubUsageTracker do
+  subject(:tracker) { described_class.new }
+  let(:influxdb_client) { double }
+  let(:logger) { double(:info) }
+
+  before do
+    allow(tracker).to receive(:influxdb).and_return(influxdb_client)
+    stub_const("Rails", double(:logger => logger))
+    stub_const("MiqBot", double(:version => "test"))
+  end
+
+  describe "#record_datapoint" do
+    after do
+      tracker.record_datapoint(requests_remaining: 1337, uri: request_uri )
+    end
+
+    context "with full URLs" do
+      let(:request_uri) { "https://api.github.com/orgs/ManageIQ" }
+      it "parses the URI correctly" do
+        expect(influxdb_client).to receive(:write_point)
+          .with('github_api_request', a_hash_including(:values => a_hash_including(:uri => "/orgs/ManageIQ")))
+      end
+    end
+
+    context "with full URLs, trailing slash" do
+      let(:request_uri) { "http://custom.githubdomain.com/orgs/ManageIQ/" }
+      it "parses the URI correctly" do
+        expect(influxdb_client).to receive(:write_point)
+          .with('github_api_request', a_hash_including(:values => a_hash_including(:uri => "/orgs/ManageIQ")))
+      end
+    end
+
+    context "with URI paths" do
+      let(:request_uri) { "/orgs/ManageIQ" }
+      it "parses the URI correctly" do
+        expect(influxdb_client).to receive(:write_point)
+          .with('github_api_request', a_hash_including(:values => a_hash_including(:uri => "/orgs/ManageIQ")))
+      end
+    end
+
+    context "with querystring" do
+      let(:request_uri) { "https://api.github.com/orgs/ManageIQ?some=thing&other=thing" }
+      it "parses the URI correctly" do
+        expect(influxdb_client).to receive(:write_point)
+          .with('github_api_request', a_hash_including(:values => a_hash_including(:uri => "/orgs/ManageIQ")))
+      end
+    end
+
+    context "with an invalid URI" do
+      let(:request_uri) { nil }
+      it "parses the URI correctly" do
+        expect(logger).to receive(:info).with(a_string_including("URI::InvalidURIError"))
+      end
+    end
+  end
+end

--- a/spec/lib/github_usage_tracker_spec.rb
+++ b/spec/lib/github_usage_tracker_spec.rb
@@ -11,7 +11,7 @@ describe GithubUsageTracker do
 
   describe "#record_datapoint" do
     after do
-      tracker.record_datapoint(requests_remaining: 1337, uri: request_uri )
+      tracker.record_datapoint(:requests_remaining => 1337, :uri => request_uri)
     end
 
     context "with full URLs" do


### PR DESCRIPTION
* Request URIs are now recorded, so we can see and quantify painpoints in our API usage
* Begins the shift to pure Octokit by configuring outside of `GithubApi`
* Reuses RateLimitLogger middleware for all Octokit requests instead of doing it's own thing