### PR TITLE
Fix Faraday middleware order

### DIFF
--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -3,7 +3,10 @@ Octokit.configure do |c|
   c.password = Settings.github_credentials.password
   c.auto_paginate = true
 
-  rack_builder = Octokit::Default.middleware
-  rack_builder.use(GithubService::Response::RatelimitLogger)
-  c.middleware = rack_builder
+  c.middleware = Faraday::RackBuilder.new do |builder|
+    builder.use GithubService::Response::RatelimitLogger
+    builder.use Octokit::Response::RaiseError
+    builder.use Octokit::Response::FeedParser
+    builder.adapter Faraday.default_adapter
+  end
 end


### PR DESCRIPTION
Apparently order matters, and we're losing some request recording because it's not wrapping other things octokit does. Adapter should always be last, as well.