### PR TITLE
Record workers from backtrace on Github requests

### DIFF
--- a/lib/github_usage_tracker.rb
+++ b/lib/github_usage_tracker.rb
@@ -8,17 +8,27 @@ class GithubUsageTracker
   def record_datapoint(requests_remaining:, uri:, timestamp: nil)
     request_uri = URI.parse(uri).path.chomp("/")
 
-    influxdb.write_point(
-      'github_api_request',
-      { :tags      => { :bot_version        => MiqBot.version },
-        :values    => { :requests_remaining => requests_remaining.to_i, :uri => request_uri },
-        :timestamp => timestamp ? timestamp.to_i : Time.now.to_i }
-    )
+    values = { :tags      => { :bot_version        => MiqBot.version },
+               :values    => { :requests_remaining => requests_remaining.to_i, :uri => request_uri },
+               :timestamp => timestamp ? timestamp.to_i : Time.now.to_i }
+
+    worker = worker_from_backtrace
+    values[:tags].merge!(:worker => worker) if worker
+
+    influxdb.write_point('github_api_request', values)
   rescue => e
     Rails.logger.info("#{e.class}: #{e.message}")
   end
 
   private
+
+  def worker_from_backtrace
+    caller.each do |l|
+      match = /(?:app\/workers\/)(?:\w+\/)*?(\w+)(?:\.rb\:\d+)/.match(l)
+      return match[1] if match && match[1].exclude?("_mixin")
+    end
+    false
+  end
 
   def influxdb
     InfluxDB::Rails.client

--- a/lib/github_usage_tracker.rb
+++ b/lib/github_usage_tracker.rb
@@ -27,7 +27,7 @@ class GithubUsageTracker
       match = /(?:app\/workers\/)(?:\w+\/)*?(\w+)(?:\.rb\:\d+)/.match(l)
       return match[1] if match && match[1].exclude?("_mixin")
     end
-    false
+    nil
   end
 
   def influxdb


### PR DESCRIPTION
Hooks in to the backtrace on recording Github API requests and tries to find a worker to blame for this request being made.