### PR TITLE
Squeeze out near nanosecond precision

### DIFF
--- a/lib/github_service/response/ratelimit_logger.rb
+++ b/lib/github_service/response/ratelimit_logger.rb
@@ -18,8 +18,7 @@ class GithubService
         logger.info { "Executed #{env.method.to_s.upcase} #{env.url}...api calls remaining #{api_calls_remaining}" }
         GithubUsageTracker.record_datapoint(
           :requests_remaining => api_calls_remaining,
-          :uri                => env.url.request_uri,
-          :timestamp          => Time.parse(env.response_headers["date"])
+          :uri                => env.url.request_uri
         )
       end
     end

--- a/lib/github_usage_tracker.rb
+++ b/lib/github_usage_tracker.rb
@@ -9,15 +9,15 @@ class GithubUsageTracker
     @influx ||= InfluxDB::Client.new(Settings.influxdb.database_name,
                                      :username => Settings.influxdb.username,
                                      :password => Settings.influxdb.password,
-                                     :time_precision => 'ms')
+                                     :time_precision => 'ns')
   end
 
-  def record_datapoint(requests_remaining:, uri:, timestamp: Time.now)
+  def record_datapoint(requests_remaining:, uri:)
     request_uri = URI.parse(uri).path.chomp("/")
 
     values = { :tags      => { :bot_version        => MiqBot.version },
                :values    => { :requests_remaining => requests_remaining.to_i, :uri => request_uri },
-               :timestamp => (timestamp.to_f * 1000).to_i } # ms precision
+               :timestamp => DateTime.now.rfc3339(9) } # Near ns precision
 
     worker = worker_from_backtrace
     values[:tags].merge!(:worker => worker) if worker


### PR DESCRIPTION
Ruby doesn't really do a lot with nanosecond precision, as it kind of pushes the limitations of the language. However, this change should squeeze out the most accurate possible* measurement of
nanoseconds I can come up with.

This change seems to often detect two of the three requests in the GithubNotificationMonitor that get called in rapid succession, instead of the one that usually gets detected in ms precision.

*Note that according to Ruby documentation, #nsec is actually a more accurate measurement of nanoseconds, but I don't see how one actually uses that to record the full timestamp as it's only the fractional bit of seconds. For more, see http://ruby-doc.org/core-2.4.0/Time.html#method-i-nsec