### PR TITLE
Use Faraday HTTP caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'rugged',                            :require => false
 
 gem 'octokit', '~> 3.8.0'
 gem 'faraday', '~> 0.9.1'
+gem 'faraday-http-cache', '~> 2.0.0'
 
 group :development, :test do
   gem 'rspec'

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -5,6 +5,7 @@ Octokit.configure do |c|
 
   c.middleware = Faraday::RackBuilder.new do |builder|
     builder.use GithubService::Response::RatelimitLogger
+    builder.use Faraday::HttpCache, :store => Rails.cache, :logger => Rails.logger
     builder.use Octokit::Response::RaiseError
     builder.use Octokit::Response::FeedParser
     builder.adapter Faraday.default_adapter


### PR DESCRIPTION
This gem adds a Faraday middleware that caches HTTP responses by checking
expiration and validation of the stored responses. It could be completely worthless given our requests/responses, or it could be a super easy win to immediately lower our API usage and get under the rate limit.

It uses the following headers to make caching decisions:

* Cache-Control
* Age
* Last-Modified
* ETag
* Expires

We might want to consider utilizing Redis for our application cache, but
I've left the default FileStore cache to use for now. Both FileStore and
Redis work across processes so workers should share the same cache
regardless.

I don't know of a very good way to test this other that just shipping it
and watching closely, which is honestly what I recommend we do. Monitor
the logs and watch hit/misses and make sure the bot is behaving and
doing it's chores. Just like having a kid, right?

...right?