### PR TITLE
Revert "Squeeze out near nanosecond precision"

### DIFF
--- a/lib/github_service/response/ratelimit_logger.rb
+++ b/lib/github_service/response/ratelimit_logger.rb
@@ -18,7 +18,8 @@ class GithubService
         logger.info { "Executed #{env.method.to_s.upcase} #{env.url}...api calls remaining #{api_calls_remaining}" }
         GithubUsageTracker.record_datapoint(
           :requests_remaining => api_calls_remaining,
-          :uri                => env.url.request_uri
+          :uri                => env.url.request_uri,
+          :timestamp          => Time.parse(env.response_headers["date"])
         )
       end
     end

--- a/lib/github_usage_tracker.rb
+++ b/lib/github_usage_tracker.rb
@@ -9,15 +9,15 @@ class GithubUsageTracker
     @influx ||= InfluxDB::Client.new(Settings.influxdb.database_name,
                                      :username => Settings.influxdb.username,
                                      :password => Settings.influxdb.password,
-                                     :time_precision => 'ns')
+                                     :time_precision => 'ms')
   end
 
-  def record_datapoint(requests_remaining:, uri:)
+  def record_datapoint(requests_remaining:, uri:, timestamp: Time.now)
     request_uri = URI.parse(uri).path.chomp("/")
 
     values = { :tags      => { :bot_version        => MiqBot.version },
                :values    => { :requests_remaining => requests_remaining.to_i, :uri => request_uri },
-               :timestamp => DateTime.now.rfc3339(9) } # Near ns precision
+               :timestamp => (timestamp.to_f * 1000).to_i } # ms precision
 
     worker = worker_from_backtrace
     values[:tags].merge!(:worker => worker) if worker


### PR DESCRIPTION
Reverts ManageIQ/miq_bot#284

Oops®

This doesn't appear to work as intended, metrics are broken.

```
InfluxDB::Error: {"error":"unable to parse 'github_api_request,bot_version=v0.0.33-6-ga596e04 requests_remaining=1i,uri=\"TEST\" 2017-02-03T11:45:52.784831000-05:00': bad timestamp"}
```