### PR TITLE
Disable caching for now

### DIFF
--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -5,7 +5,7 @@ Octokit.configure do |c|
 
   c.middleware = Faraday::RackBuilder.new do |builder|
     builder.use GithubService::Response::RatelimitLogger
-    builder.use Faraday::HttpCache, :store => Rails.cache, :logger => Rails.logger
+    # builder.use Faraday::HttpCache, :store => Rails.cache, :logger => Rails.logger
     builder.use Octokit::Response::RaiseError
     builder.use Octokit::Response::FeedParser
     builder.adapter Faraday.default_adapter


### PR DESCRIPTION
We're seeing some odd behavior with the bot responding again after doing
so earlier; since we got so much from the optimizations let's try
without caching and see where that leaves us.

As long as it's under the rate limit, we're moving on to webhooks
eventually anyway.