### PR TITLE
Ignore .ruby_version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+.ruby-version
+
 # Ignore bundler config.
 /.bundle
 


### PR DESCRIPTION
Followup to #299

Makes it easy to set ruby version locally to whatever you want without gitignoring yourself, and more importantly serves as an indicator that we *intend* that we're not locking the Ruby version.