### PR TITLE
New GithubService singleton wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,5 +63,6 @@ group :development, :test do
 end
 
 group :test do
+  gem 'webmock'
   gem 'factory_girl_rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
       activesupport (>= 3.0)
       deep_merge (~> 1.0, >= 1.0.1)
     connection_pool (2.2.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     daemons (1.2.3)
     declarative (0.0.8)
       uber (>= 0.0.15)
@@ -141,6 +143,7 @@ GEM
       rake (>= 10, < 13)
       rubocop (>= 0.47.0)
       sysexits (~> 1.1)
+    hashdiff (0.3.2)
     hashie (3.4.6)
     highline (1.7.8)
     hike (1.2.3)
@@ -266,6 +269,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     rugged (0.24.0)
+    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -352,6 +356,10 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket (1.2.3)
 
 PLATFORMS
@@ -392,6 +400,7 @@ DEPENDENCIES
   travis (~> 1.7.6)
   turbolinks
   uglifier (>= 1.3.0)
+  webmock
 
 BUNDLED WITH
    1.13.7

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -80,6 +80,10 @@ class Branch < ActiveRecord::Base
     NewGithubService.add_comments(repo.name, pr_number, message_builder.comments)
   end
 
+  def fq_repo_name
+    repo.name
+  end
+
   def git_service
     GitService::Branch.new(self)
   end

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -77,11 +77,7 @@ class Branch < ActiveRecord::Base
     message_builder.write(message) if message
 
     logger.info("Writing comment with header: #{header}")
-    repo.with_github_service do |github|
-      # TODO: Refactor the common "delete prior tagged issues" into miq_tools_services
-      # github.delete_issue_comments(pr_number, header)
-      github.create_issue_comments(pr_number, message_builder.comments)
-    end
+    GithubService.add_comments(repo.name, pr_number, message_builder.comments)
   end
 
   def git_service

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -77,7 +77,7 @@ class Branch < ActiveRecord::Base
     message_builder.write(message) if message
 
     logger.info("Writing comment with header: #{header}")
-    GithubService.add_comments(repo.name, pr_number, message_builder.comments)
+    NewGithubService.add_comments(repo.name, pr_number, message_builder.comments)
   end
 
   def git_service

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -62,11 +62,6 @@ class Repo < ActiveRecord::Base
     end
   end
 
-  def with_github_service
-    raise "no block given" unless block_given?
-    GithubService.call(:user => upstream_user, :repo => project) { |github| yield github }
-  end
-
   def with_travis_service
     raise "no block given" unless block_given?
 

--- a/app/views/main/_commit_monitor.html.erb
+++ b/app/views/main/_commit_monitor.html.erb
@@ -12,7 +12,7 @@
 		<tbody>
 			<% @branches.each do |branch| %>
 				<tr>
-					<td><%= branch.repo.name %></td>
+					<td><%= branch.fq_repo_name %></td>
 					<td><%= branch.name %></td>
 					<td><%= link_to(branch.last_commit[0, 8], branch.last_commit_uri, :target => "_blank") %></td>
 					<td><%= time_ago_in_words_with_nil_check(branch.last_checked_on) %></td>

--- a/app/workers/commit_monitor_handlers/batch/github_pr_commenter.rb
+++ b/app/workers/commit_monitor_handlers/batch/github_pr_commenter.rb
@@ -45,7 +45,7 @@ module CommitMonitorHandlers::Batch
     def replace_batch_comments
       logger.info("Adding batch comment to PR #{pr_number}.")
 
-      NewGithubService.replace_comments(branch.repo.name, pr_number, new_comments) do |old_comment|
+      NewGithubService.replace_comments(fq_repo_name, pr_number, new_comments) do |old_comment|
         batch_comment?(old_comment)
       end
     end

--- a/app/workers/commit_monitor_handlers/batch/github_pr_commenter.rb
+++ b/app/workers/commit_monitor_handlers/batch/github_pr_commenter.rb
@@ -28,8 +28,6 @@ module CommitMonitorHandlers::Batch
 
     private
 
-    attr_reader :github
-
     def tag
       "<github-pr-commenter-batch />"
     end

--- a/app/workers/commit_monitor_handlers/batch/github_pr_commenter.rb
+++ b/app/workers/commit_monitor_handlers/batch/github_pr_commenter.rb
@@ -22,7 +22,7 @@ module CommitMonitorHandlers::Batch
         return
       end
 
-      process
+      replace_batch_comments
       complete_batch_job
     end
 
@@ -42,17 +42,10 @@ module CommitMonitorHandlers::Batch
       "#{tag}**...continued**\n"
     end
 
-    def process
+    def replace_batch_comments
       logger.info("Adding batch comment to PR #{pr_number}.")
 
-      branch.repo.with_github_service do |github|
-        @github = github
-        replace_batch_comments
-      end
-    end
-
-    def replace_batch_comments
-      github.replace_issue_comments(pr_number, new_comments) do |old_comment|
+      NewGithubService.replace_comments(branch.repo.name, pr_number, new_comments) do |old_comment|
         batch_comment?(old_comment)
       end
     end

--- a/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
+++ b/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
@@ -59,8 +59,4 @@ class CommitMonitorHandlers::Branch::PrMergeabilityChecker
   rescue Octokit::NotFound
     # This label is not currently applied, skip
   end
-
-  def fq_repo_name
-    branch.repo.name
-  end
 end

--- a/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
+++ b/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
@@ -40,27 +40,29 @@ class CommitMonitorHandlers::Branch::PrMergeabilityChecker
   def write_to_github
     logger.info("Updating PR #{branch.pr_number} with mergability comment.")
 
-    branch.repo.with_github_service do |github|
-      github.create_issue_comments(branch.pr_number, "#{tag}This pull request is not mergeable.  Please rebase and repush.")
-    end
+    NewGithubService.add_comment(
+      fq_repo_name,
+      branch.pr_number,
+      "#{tag}This pull request is not mergeable.  Please rebase and repush."
+    )
   end
 
   def apply_label
     logger.info("Updating PR #{branch.pr_number} with label #{LABEL.inspect}.")
 
-    branch.repo.with_github_service do |github|
-      github.add_issue_labels(branch.pr_number, LABEL)
-    end
+    NewGithubService.add_labels_to_an_issue(fq_repo_name, branch.pr_number, [LABEL])
   end
 
   def remove_label
     logger.info("Updating PR #{branch.pr_number} my removing label #{LABEL.inspect}.")
+    NewGithubService.remove_label(fq_repo_name, branch.pr_number, LABEL)
+  rescue Octokit::NotFound
+    # This label is not currently applied, skip
+  end
 
-    branch.repo.with_github_service do |github|
-      begin
-        github.issues.labels.remove(github.user, github.repo, branch.pr_number, :label_name => LABEL)
-      rescue Github::Error::NotFound # This label is not currently applied, skip
-      end
-    end
+  private
+
+  def fq_repo_name
+    branch.repo.name
   end
 end

--- a/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
+++ b/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
@@ -60,8 +60,6 @@ class CommitMonitorHandlers::Branch::PrMergeabilityChecker
     # This label is not currently applied, skip
   end
 
-  private
-
   def fq_repo_name
     branch.repo.name
   end

--- a/app/workers/commit_monitor_handlers/commit/bugzilla_commenter.rb
+++ b/app/workers/commit_monitor_handlers/commit/bugzilla_commenter.rb
@@ -27,7 +27,7 @@ module CommitMonitorHandlers
       private
 
       def bugzilla_comment
-        prefix     = "New commit detected on #{branch.repo.name}/#{branch.name}:"
+        prefix     = "New commit detected on #{fq_repo_name}/#{branch.name}:"
         commit_uri = branch.commit_uri_to(commit)
         comment    = "#{prefix}\n#{commit_uri}\n\n#{message}"
         comment

--- a/app/workers/commit_monitor_handlers/commit_range/gem_changes_labeler.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/gem_changes_labeler.rb
@@ -38,6 +38,6 @@ class CommitMonitorHandlers::CommitRange::GemChangesLabeler
 
   def apply_label
     logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
-    NewGithubService.add_labels_to_an_issue(branch.repo.name, pr_number, [LABEL])
+    NewGithubService.add_labels_to_an_issue(fq_repo_name, pr_number, [LABEL])
   end
 end

--- a/app/workers/commit_monitor_handlers/commit_range/gem_changes_labeler.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/gem_changes_labeler.rb
@@ -37,9 +37,7 @@ class CommitMonitorHandlers::CommitRange::GemChangesLabeler
   end
 
   def apply_label
-    branch.repo.with_github_service do |github|
-      logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
-      github.add_issue_labels(pr_number, LABEL)
-    end
+    logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
+    NewGithubService.add_labels_to_an_issue(branch.repo.name, pr_number, [LABEL])
   end
 end

--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -33,7 +33,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
       @results     = RubocopResultsFilter.new(results, diff_details).filtered
     end
 
-    write_to_github
+    replace_rubocop_comments
   rescue Rugged::IndexError
     # Failed to create merge index, no point in trying to lint files for an unmergable PR
   end
@@ -57,17 +57,9 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
     MessageBuilder.new(results, branch).comments
   end
 
-  def write_to_github
-    logger.info("Updating PR #{pr_number} with rubocop comment.")
-
-    branch.repo.with_github_service do |github|
-      @github = github
-      replace_rubocop_comments
-    end
-  end
-
   def replace_rubocop_comments
-    github.replace_issue_comments(pr_number, rubocop_comments) do |old_comment|
+    logger.info("Updating PR #{pr_number} with rubocop comment.")
+    NewGithubService.replace_comments(branch.repo.name, pr_number, rubocop_comments) do |old_comment|
       rubocop_comment?(old_comment)
     end
   end

--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -59,7 +59,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
 
   def replace_rubocop_comments
     logger.info("Updating PR #{pr_number} with rubocop comment.")
-    NewGithubService.replace_comments(branch.repo.name, pr_number, rubocop_comments) do |old_comment|
+    NewGithubService.replace_comments(fq_repo_name, pr_number, rubocop_comments) do |old_comment|
       rubocop_comment?(old_comment)
     end
   end

--- a/app/workers/commit_monitor_handlers/commit_range/sql_migration_labeler.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/sql_migration_labeler.rb
@@ -37,9 +37,7 @@ class CommitMonitorHandlers::CommitRange::SqlMigrationLabeler
   end
 
   def apply_label
-    branch.repo.with_github_service do |github|
-      logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
-      github.add_issue_labels(pr_number, LABEL)
-    end
+    logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
+    NewGithubService.add_labels_to_an_issue(branch.repo.name, pr_number, [LABEL])
   end
 end

--- a/app/workers/commit_monitor_handlers/commit_range/sql_migration_labeler.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/sql_migration_labeler.rb
@@ -38,6 +38,6 @@ class CommitMonitorHandlers::CommitRange::SqlMigrationLabeler
 
   def apply_label
     logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
-    NewGithubService.add_labels_to_an_issue(branch.repo.name, pr_number, [LABEL])
+    NewGithubService.add_labels_to_an_issue(fq_repo_name, pr_number, [LABEL])
   end
 end

--- a/app/workers/concerns/branch_worker_mixin.rb
+++ b/app/workers/concerns/branch_worker_mixin.rb
@@ -1,7 +1,7 @@
 module BranchWorkerMixin
   attr_reader :branch
 
-  delegate :pr_number, :pr_title, :pr_title_tags, :merge_target, :to => :branch
+  delegate :fq_repo_name, :pr_number, :pr_title, :pr_title_tags, :merge_target, :to => :branch
 
   def find_branch(branch_id, required_mode = nil)
     @branch = Branch.where(:id => branch_id).first
@@ -41,7 +41,7 @@ module BranchWorkerMixin
 
   def verify_branch_enabled
     branch_enabled?.tap do |enabled|
-      logger.warn("#{branch.repo.name} has not been enabled.  Skipping.") unless enabled
+      logger.warn("#{fq_repo_name} has not been enabled.  Skipping.") unless enabled
     end
   end
 

--- a/app/workers/pull_request_monitor.rb
+++ b/app/workers/pull_request_monitor.rb
@@ -41,12 +41,12 @@ class PullRequestMonitor
 
   def github_prs(repo)
     NewGithubService.pull_requests(repo.name).map do |github_pr|
-        {
-          :number       => github_pr.number,
-          :html_url     => github_pr.head.repo.try(:html_url) || github_pr.base.repo.html_url,
-          :merge_target => github_pr.base.ref,
-          :pr_title     => github_pr.title
-        }
+      {
+        :number       => github_pr.number,
+        :html_url     => github_pr.head.repo.try(:html_url) || github_pr.base.repo.html_url,
+        :merge_target => github_pr.base.ref,
+        :pr_title     => github_pr.title
+      }
     end
   end
 end

--- a/app/workers/pull_request_monitor.rb
+++ b/app/workers/pull_request_monitor.rb
@@ -40,15 +40,13 @@ class PullRequestMonitor
   private
 
   def github_prs(repo)
-    repo.with_github_service do |github|
-      github.pull_requests.all.collect do |github_pr|
+    NewGithubService.pull_requests(repo.name).map do |github_pr|
         {
           :number       => github_pr.number,
           :html_url     => github_pr.head.repo.try(:html_url) || github_pr.base.repo.html_url,
           :merge_target => github_pr.base.ref,
           :pr_title     => github_pr.title
         }
-      end
     end
   end
 end

--- a/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
+++ b/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
@@ -22,15 +22,8 @@ class PullRequestMonitorHandlers::MergeTargetTitler
   end
 
   def apply_title
-    branch.repo.with_github_service do |github|
-      logger.info("Updating PR #{pr_number} with title change for merge target #{merge_target}.")
-      github.pull_requests.update(
-        :user   => github.user,
-        :repo   => github.repo,
-        :number => pr_number,
-        :title  => new_pr_title
-      )
-    end
+    logger.info("Updating PR #{pr_number} with title change for merge target #{merge_target}.")
+    GithubService.update_pull_request(branch.repo.name, pr_number, :title => new_pr_title)
   end
 
   def new_pr_title

--- a/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
+++ b/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
@@ -23,7 +23,7 @@ class PullRequestMonitorHandlers::MergeTargetTitler
 
   def apply_title
     logger.info("Updating PR #{pr_number} with title change for merge target #{merge_target}.")
-    NewGithubService.update_pull_request(branch.repo.name, pr_number, :title => new_pr_title)
+    NewGithubService.update_pull_request(fq_repo_name, pr_number, :title => new_pr_title)
   end
 
   def new_pr_title

--- a/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
+++ b/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
@@ -23,7 +23,7 @@ class PullRequestMonitorHandlers::MergeTargetTitler
 
   def apply_title
     logger.info("Updating PR #{pr_number} with title change for merge target #{merge_target}.")
-    GithubService.update_pull_request(branch.repo.name, pr_number, :title => new_pr_title)
+    NewGithubService.update_pull_request(branch.repo.name, pr_number, :title => new_pr_title)
   end
 
   def new_pr_title

--- a/app/workers/pull_request_monitor_handlers/wip_labeler.rb
+++ b/app/workers/pull_request_monitor_handlers/wip_labeler.rb
@@ -29,11 +29,11 @@ class PullRequestMonitorHandlers::WipLabeler
 
   def apply_label
     logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
-    NewGithubService.add_labels_to_an_issue(branch.repo.name, pr_number, [LABEL])
+    NewGithubService.add_labels_to_an_issue(fq_repo_name, pr_number, [LABEL])
   end
 
   def remove_label
     logger.info("Updating PR #{pr_number} without label #{LABEL.inspect}.")
-    NewGithubService.remove_label(branch.repo.name, pr_number, LABEL)
+    NewGithubService.remove_label(fq_repo_name, pr_number, LABEL)
   end
 end

--- a/app/workers/pull_request_monitor_handlers/wip_labeler.rb
+++ b/app/workers/pull_request_monitor_handlers/wip_labeler.rb
@@ -28,16 +28,12 @@ class PullRequestMonitorHandlers::WipLabeler
   end
 
   def apply_label
-    branch.repo.with_github_service do |github|
-      logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
-      github.add_issue_labels(pr_number, LABEL)
-    end
+    logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
+    NewGithubService.add_labels_to_an_issue(branch.repo.name, pr_number, [LABEL])
   end
 
   def remove_label
-    branch.repo.with_github_service do |github|
-      logger.info("Updating PR #{pr_number} without label #{LABEL.inspect}.")
-      github.remove_issue_labels(pr_number, LABEL)
-    end
+    logger.info("Updating PR #{pr_number} without label #{LABEL.inspect}.")
+    NewGithubService.remove_label(branch.repo.name, pr_number, LABEL)
   end
 end

--- a/lib/backporting.rb
+++ b/lib/backporting.rb
@@ -4,12 +4,8 @@ module Backporting
   # Backport requests are merged pull requests from the ManageIQ repos marked by
   # labels such as 'darga/yes'
   def self.search_for_backport_requests(branch)
-    GithubService.call({}) do |github|
-      github.search.issues(
-        :q     => "user:ManageIQ is:merged label:#{branch}/yes",
-        :sort  => "updated",
-        :order => "desc"
-      )
-    end.items
+    NewGithubService.search_issues("user:ManageIQ is:merged label:#{branch}/yes",
+                                   :sort  => "updated",
+                                   :order => "desc").items
   end
 end

--- a/lib/new_github_service.rb
+++ b/lib/new_github_service.rb
@@ -35,11 +35,29 @@ module NewGithubService
         end
     end
 
-    # -> GithubService.create_issue_comments
-    def add_comments(fq_repo_name, issue_id, comments)
+    # DEPRECATES GithubService.create_issue_comments
+    def add_comments(fq_repo_name, issue_number, comments)
       Array(comments).each do |comment|
-        add_comment(fq_repo_name, issue_id, comment)
+        add_comment(fq_repo_name, issue_number, comment)
       end
+    end
+
+    # DEPRECATES GithubService.delete_issue_comments
+    def delete_comments(fq_repo_name, comment_ids)
+      Array(comment_ids).each do |comment_id|
+        delete_comment(fq_repo_name, comment_id)
+      end
+    end
+
+    # Deletes the issue comments found by the provided block, then creates new
+    # issue comments from those provided.
+    # DEPRECATES GithubService.replace_issue_comments
+    def replace_comments(fq_repo_name, issue_number, new_comments, &block)
+      raise "no block given" unless block_given?
+
+      to_delete = GithubService.issue_comments(fq_repo_name, issue_number).select { |c| yield c }
+      delete_comments(fq_repo_name, to_delete.map(&:id))
+      add_comments(fq_repo_name, issue_number, new_comments)
     end
 
     private

--- a/lib/new_github_service.rb
+++ b/lib/new_github_service.rb
@@ -12,7 +12,7 @@ module NewGithubService
   #
   class << self
     def service
-      @service ||= \
+      @service ||=
         begin
           require 'octokit'
 

--- a/lib/new_github_service.rb
+++ b/lib/new_github_service.rb
@@ -55,7 +55,7 @@ module NewGithubService
     def replace_comments(fq_repo_name, issue_number, new_comments)
       raise "no block given" unless block_given?
 
-      to_delete = GithubService.issue_comments(fq_repo_name, issue_number).select { |c| yield c }
+      to_delete = issue_comments(fq_repo_name, issue_number).select { |c| yield c }
       delete_comments(fq_repo_name, to_delete.map(&:id))
       add_comments(fq_repo_name, issue_number, new_comments)
     end

--- a/lib/new_github_service.rb
+++ b/lib/new_github_service.rb
@@ -35,6 +35,13 @@ module NewGithubService
         end
     end
 
+    # -> GithubService.create_issue_comments
+    def add_comments(fq_repo_name, issue_id, comments)
+      Array(comments).each do |comment|
+        add_comment(fq_repo_name, issue_id, comment)
+      end
+    end
+
     private
 
     def respond_to_missing?(method_name, include_private=false)

--- a/lib/new_github_service.rb
+++ b/lib/new_github_service.rb
@@ -52,7 +52,7 @@ module NewGithubService
     # Deletes the issue comments found by the provided block, then creates new
     # issue comments from those provided.
     # DEPRECATES GithubService.replace_issue_comments
-    def replace_comments(fq_repo_name, issue_number, new_comments, &block)
+    def replace_comments(fq_repo_name, issue_number, new_comments)
       raise "no block given" unless block_given?
 
       to_delete = GithubService.issue_comments(fq_repo_name, issue_number).select { |c| yield c }
@@ -62,8 +62,8 @@ module NewGithubService
 
     private
 
-    def respond_to_missing?(method_name, include_private=false)
-      service.respond_to?(method_name)
+    def respond_to_missing?(method_name, include_private = false)
+      service.respond_to?(method_name, include_private)
     end
 
     def method_missing(method_name, *args, &block)

--- a/lib/new_github_service.rb
+++ b/lib/new_github_service.rb
@@ -1,0 +1,52 @@
+module NewGithubService
+  ##
+  # GithubService is miq-bot's interface to the Github API. It acts as a
+  # wrapper around Octokit, delegating calls directly to the Octokit client as
+  # well as providing a space to keep useful augmentations of the interface for
+  # our own use cases.
+  #
+  # You can find the official Octokit documentation at http://octokit.github.io/octokit.rb
+  #
+  # Please check the documentation first before adding helper methods, as they
+  # may already be well handled by Octokit itself.
+  #
+  class << self
+    def service
+      @service ||= \
+        begin
+          require 'octokit'
+
+          unless Rails.env.test?
+            Octokit.configure do |c|
+              c.login    = Settings.github_credentials.username
+              c.password = Settings.github_credentials.password
+              c.auto_paginate = true
+
+              c.middleware = Faraday::RackBuilder.new do |builder|
+                builder.use GithubService::Response::RatelimitLogger
+                builder.use Octokit::Response::RaiseError
+                builder.use Octokit::Response::FeedParser
+                builder.adapter Faraday.default_adapter
+              end
+            end
+          end
+
+          Octokit::Client.new
+        end
+    end
+
+    private
+
+    def respond_to_missing?(method_name, include_private=false)
+      service.respond_to?(method_name)
+    end
+
+    def method_missing(method_name, *args, &block)
+      if service.respond_to?(method_name)
+        service.send(method_name, *args, &block)
+      else
+        super
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,11 @@ RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
 
   config.include FactoryGirl::Syntax::Methods
+
+  config.before do
+    allow_any_instance_of(MinigitService).to receive(:service)
+      .and_raise("Live execution is not allowed in specs.  Use stubs/expectations on service instead.")
+  end
 end
 
 WebMock.disable_net_connect!(:allow_localhost => true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,4 +45,4 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 end
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(:allow_localhost => true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'webmock/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -42,16 +43,6 @@ RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
 
   config.include FactoryGirl::Syntax::Methods
-
-  config.before do
-    [
-      BugzillaService,
-      GithubService,
-      MinigitService
-    ].each do |service_model|
-      allow_any_instance_of(service_model).to receive(:service).and_raise(
-        "Live execution is not allowed in specs.  Use stubs/expectations on service instead."
-      )
-    end
-  end
 end
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/support/services_helper.rb
+++ b/spec/support/services_helper.rb
@@ -4,10 +4,9 @@ def stub_github_service
   end
 end
 
-def stub_github_prs(github, *prs)
+def stub_github_prs(*prs)
   prs.flatten!
   prs.collect! { |i| double("Github PR #{i}", :number => i) } if prs.first.kind_of?(Numeric)
 
-  relation = double("Github PR relation", :all => prs)
-  expect(github).to receive(:pull_requests).and_return(relation)
+  expect(NewGithubService).to receive(:pull_requests).and_return(prs)
 end

--- a/spec/support/services_helper.rb
+++ b/spec/support/services_helper.rb
@@ -1,9 +1,3 @@
-def stub_github_service
-  double("Github service").tap do |github|
-    allow(GithubService).to receive(:call).and_yield(github)
-  end
-end
-
 def stub_github_prs(*prs)
   prs.flatten!
   prs.collect! { |i| double("Github PR #{i}", :number => i) } if prs.first.kind_of?(Numeric)

--- a/spec/workers/commit_monitor_handlers/branch/pr_mergeability_checker_spec.rb
+++ b/spec/workers/commit_monitor_handlers/branch/pr_mergeability_checker_spec.rb
@@ -5,16 +5,17 @@ describe CommitMonitorHandlers::Branch::PrMergeabilityChecker do
     stub_sidekiq_logger
   end
 
-  let(:github_service) { stub_github_service }
   let(:pr_branch) { create(:pr_branch, :name => 'prs/1/head', :mergeable => true) }
+  let(:repo_name) { pr_branch.repo.name }
 
   context 'when PR was mergeable and becomes unmergeable' do
     it 'comments on the PR' do
       git_service = instance_double('GitService::Branch', :mergeable? => false)
       allow(GitService::Branch).to receive(:new) { git_service }
-      allow(github_service).to receive(:add_issue_labels)
+      allow(NewGithubService).to receive(:add_labels_to_an_issue)
 
-      expect(github_service).to receive(:create_issue_comments)
+      expect(NewGithubService).to receive(:add_comment)
+        .with(repo_name, 1, a_string_including("not mergeable"))
 
       described_class.new.perform(pr_branch.id)
     end
@@ -22,28 +23,27 @@ describe CommitMonitorHandlers::Branch::PrMergeabilityChecker do
     it "adds an 'unmergeable' label to the PR" do
       git_service = instance_double('GitService::Branch', :mergeable? => false)
       allow(GitService::Branch).to receive(:new) { git_service }
-      allow(github_service).to receive(:create_issue_comments)
+      allow(NewGithubService).to receive(:add_comment)
 
-      expect(github_service).to receive(:add_issue_labels).with(1, 'unmergeable')
+      expect(NewGithubService).to receive(:add_labels_to_an_issue)
+        .with(repo_name, 1, ['unmergeable'])
 
       described_class.new.perform(pr_branch.id)
     end
   end
 
   context 'when PR was unmergeable and becomes mergeable' do
-    let(:unmergeable_pr_branch) { create(:pr_branch, :name => 'prs/1/head', :mergeable => false) }
+    let(:pr_branch) { create(:pr_branch, :name => 'prs/1/head', :mergeable => false) }
 
     it "removes an 'unmergeable' label from the PR" do
       git_service = instance_double('GitService::Branch', :mergeable? => true)
       allow(GitService::Branch).to receive(:new) { git_service }
-      allow(github_service).to receive(:create_issue_comments)
+      allow(NewGithubService).to receive(:add_comment)
 
-      allow(github_service).to receive(:user) { 'ManageIQ' }
-      allow(github_service).to receive(:repo) { 'miq_bot' }
-      expect(github_service).to receive_message_chain(:issues, :labels, :remove)
-        .with('ManageIQ', 'miq_bot', 1, :label_name => 'unmergeable')
+      expect(NewGithubService).to receive(:remove_label)
+        .with(repo_name, 1, 'unmergeable')
 
-      described_class.new.perform(unmergeable_pr_branch.id)
+      described_class.new.perform(pr_branch.id)
     end
   end
 end

--- a/spec/workers/commit_monitor_handlers/commit_range/gem_changes_labeler_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/gem_changes_labeler_spec.rb
@@ -1,7 +1,6 @@
 describe CommitMonitorHandlers::CommitRange::GemChangesLabeler do
   let(:branch)         { create(:pr_branch) }
   let(:git_service)    { double("GitService", :diff => double("RuggedDiff", :new_files => new_files)) }
-  let(:github_service) { stub_github_service }
 
   before do
     stub_sidekiq_logger
@@ -13,7 +12,7 @@ describe CommitMonitorHandlers::CommitRange::GemChangesLabeler do
     let(:new_files) { ["Gemfile", "some/other/file.rb"] }
 
     it "adds a label to the PR" do
-      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "gem changes")
+      expect(NewGithubService).to receive(:add_labels_to_an_issue).with(branch.repo.name, branch.pr_number, ["gem changes"])
 
       described_class.new.perform(branch.id, nil)
     end
@@ -23,7 +22,7 @@ describe CommitMonitorHandlers::CommitRange::GemChangesLabeler do
     let(:new_files) { ["some_gem.gemspec", "some/other/file.rb"] }
 
     it "adds a label to the PR" do
-      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "gem changes")
+      expect(NewGithubService).to receive(:add_labels_to_an_issue).with(branch.repo.name, branch.pr_number, ["gem changes"])
 
       described_class.new.perform(branch.id, nil)
     end
@@ -33,7 +32,7 @@ describe CommitMonitorHandlers::CommitRange::GemChangesLabeler do
     let(:new_files) { ["gems/pending/Gemfile", "some/other/file.rb"] }
 
     it "adds a label to the PR" do
-      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "gem changes")
+      expect(NewGithubService).to receive(:add_labels_to_an_issue).with(branch.repo.name, branch.pr_number, ["gem changes"])
 
       described_class.new.perform(branch.id, nil)
     end
@@ -43,7 +42,7 @@ describe CommitMonitorHandlers::CommitRange::GemChangesLabeler do
     let(:new_files) { ["path/to/some_gem.gemspec", "some/other/file.rb"] }
 
     it "adds a label to the PR" do
-      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "gem changes")
+      expect(NewGithubService).to receive(:add_labels_to_an_issue).with(branch.repo.name, branch.pr_number, ["gem changes"])
 
       described_class.new.perform(branch.id, nil)
     end
@@ -53,7 +52,7 @@ describe CommitMonitorHandlers::CommitRange::GemChangesLabeler do
     let(:new_files) { ["some/other/file.rb"] }
 
     it "does not add a label to the PR" do
-      expect(github_service).to_not receive(:add_issue_labels)
+      expect(NewGithubService).to_not receive(:add_labels_to_an_issue)
 
       described_class.new.perform(branch.id, nil)
     end

--- a/spec/workers/commit_monitor_handlers/commit_range/sql_migration_labeler_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/sql_migration_labeler_spec.rb
@@ -1,7 +1,6 @@
 describe CommitMonitorHandlers::CommitRange::SqlMigrationLabeler do
   let(:branch)         { create(:pr_branch) }
   let(:git_service)    { double("GitService", :diff => double("RuggedDiff", :new_files => new_files)) }
-  let(:github_service) { stub_github_service }
 
   before do
     stub_sidekiq_logger
@@ -13,7 +12,7 @@ describe CommitMonitorHandlers::CommitRange::SqlMigrationLabeler do
     let(:new_files) { ["db/migrate/20160706230546_some_migration.rb", "some/other/file.rb"] }
 
     it "adds a label to the PR" do
-      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "sql migration")
+      expect(NewGithubService).to receive(:add_labels_to_an_issue).with(branch.repo.name, branch.pr_number, ["sql migration"])
 
       described_class.new.perform(branch.id, nil)
     end
@@ -23,7 +22,7 @@ describe CommitMonitorHandlers::CommitRange::SqlMigrationLabeler do
     let(:new_files) { ["some/other/file.rb"] }
 
     it "does not add a label to the PR" do
-      expect(github_service).to_not receive(:add_issue_labels)
+      expect(NewGithubService).to_not receive(:add_labels_to_an_issue)
 
       described_class.new.perform(branch.id, nil)
     end
@@ -33,7 +32,7 @@ describe CommitMonitorHandlers::CommitRange::SqlMigrationLabeler do
     let(:new_files) { ["spec/db/migrate/20160706230546_some_migration_spec.rb", "some/other/file.rb"] }
 
     it "does not add a label to the PR" do
-      expect(github_service).to_not receive(:add_issue_labels)
+      expect(NewGithubService).to_not receive(:add_labels_to_an_issue)
 
       described_class.new.perform(branch.id, nil)
     end

--- a/spec/workers/pull_request_monitor_handlers/merge_target_titler_spec.rb
+++ b/spec/workers/pull_request_monitor_handlers/merge_target_titler_spec.rb
@@ -1,5 +1,5 @@
 describe PullRequestMonitorHandlers::MergeTargetTitler do
-  let(:branch)         { create(:pr_branch) }
+  let(:branch) { create(:pr_branch) }
 
   before do
     stub_sidekiq_logger
@@ -37,7 +37,7 @@ describe PullRequestMonitorHandlers::MergeTargetTitler do
   it "when the branch has a master merge target" do
     branch.update_attributes!(:merge_target => "master")
 
-      expect(NewGithubService).to_not receive(:pull_requests)
+    expect(NewGithubService).to_not receive(:pull_requests)
 
     described_class.new.perform(branch.id)
   end

--- a/spec/workers/pull_request_monitor_handlers/merge_target_titler_spec.rb
+++ b/spec/workers/pull_request_monitor_handlers/merge_target_titler_spec.rb
@@ -12,7 +12,7 @@ describe PullRequestMonitorHandlers::MergeTargetTitler do
     end
 
     it "and not already titled" do
-      expect(GithubService).to receive(:update_pull_request)
+      expect(NewGithubService).to receive(:update_pull_request)
         .with(branch.repo.name, branch.pr_number, a_hash_including(:title => "[DARGA] #{branch.pr_title}"))
       described_class.new.perform(branch.id)
     end
@@ -20,7 +20,7 @@ describe PullRequestMonitorHandlers::MergeTargetTitler do
     it "and already titled" do
       branch.update_attributes!(:pr_title => "[DARGA] #{branch.pr_title}")
 
-      expect(GithubService).to_not receive(:pull_requests)
+      expect(NewGithubService).to_not receive(:pull_requests)
 
       described_class.new.perform(branch.id)
     end
@@ -28,7 +28,7 @@ describe PullRequestMonitorHandlers::MergeTargetTitler do
     it "and already titled, but not at the start" do
       branch.update_attributes!(:pr_title => "[WIP] [DARGA] #{branch.pr_title}")
 
-      expect(GithubService).to_not receive(:pull_requests)
+      expect(NewGithubService).to_not receive(:pull_requests)
 
       described_class.new.perform(branch.id)
     end
@@ -37,7 +37,7 @@ describe PullRequestMonitorHandlers::MergeTargetTitler do
   it "when the branch has a master merge target" do
     branch.update_attributes!(:merge_target => "master")
 
-      expect(GithubService).to_not receive(:pull_requests)
+      expect(NewGithubService).to_not receive(:pull_requests)
 
     described_class.new.perform(branch.id)
   end

--- a/spec/workers/pull_request_monitor_handlers/merge_target_titler_spec.rb
+++ b/spec/workers/pull_request_monitor_handlers/merge_target_titler_spec.rb
@@ -1,6 +1,5 @@
 describe PullRequestMonitorHandlers::MergeTargetTitler do
   let(:branch)         { create(:pr_branch) }
-  let(:github_service) { stub_github_service }
 
   before do
     stub_sidekiq_logger
@@ -13,22 +12,15 @@ describe PullRequestMonitorHandlers::MergeTargetTitler do
     end
 
     it "and not already titled" do
-      expect(github_service).to receive(:user).and_return("SomeUser")
-      expect(github_service).to receive(:repo).and_return("some_repo")
-      expect(github_service).to receive_message_chain(:pull_requests, :update).with(
-        :user   => "SomeUser",
-        :repo   => "some_repo",
-        :number => branch.pr_number,
-        :title  => "[DARGA] #{branch.pr_title}"
-      )
-
+      expect(GithubService).to receive(:update_pull_request)
+        .with(branch.repo.name, branch.pr_number, a_hash_including(:title => "[DARGA] #{branch.pr_title}"))
       described_class.new.perform(branch.id)
     end
 
     it "and already titled" do
       branch.update_attributes!(:pr_title => "[DARGA] #{branch.pr_title}")
 
-      expect(github_service).to_not receive(:pull_requests)
+      expect(GithubService).to_not receive(:pull_requests)
 
       described_class.new.perform(branch.id)
     end
@@ -36,7 +28,7 @@ describe PullRequestMonitorHandlers::MergeTargetTitler do
     it "and already titled, but not at the start" do
       branch.update_attributes!(:pr_title => "[WIP] [DARGA] #{branch.pr_title}")
 
-      expect(github_service).to_not receive(:pull_requests)
+      expect(GithubService).to_not receive(:pull_requests)
 
       described_class.new.perform(branch.id)
     end
@@ -45,7 +37,7 @@ describe PullRequestMonitorHandlers::MergeTargetTitler do
   it "when the branch has a master merge target" do
     branch.update_attributes!(:merge_target => "master")
 
-      expect(github_service).to_not receive(:pull_requests)
+      expect(GithubService).to_not receive(:pull_requests)
 
     described_class.new.perform(branch.id)
   end

--- a/spec/workers/pull_request_monitor_handlers/wip_labeler_spec.rb
+++ b/spec/workers/pull_request_monitor_handlers/wip_labeler_spec.rb
@@ -1,6 +1,5 @@
 describe PullRequestMonitorHandlers::WipLabeler do
   let(:branch)         { create(:pr_branch) }
-  let(:github_service) { stub_github_service }
 
   before do
     stub_sidekiq_logger
@@ -9,7 +8,7 @@ describe PullRequestMonitorHandlers::WipLabeler do
 
   context "when the PR title does not have [WIP]" do
     it "removes the wip label if it exists" do
-      expect(github_service).to receive(:remove_issue_labels).with(branch.pr_number, "wip")
+      expect(NewGithubService).to receive(:remove_label).with(branch.repo.name, branch.pr_number, "wip")
 
       described_class.new.perform(branch.id)
     end
@@ -19,7 +18,7 @@ describe PullRequestMonitorHandlers::WipLabeler do
     it "adds the wip label if it does not exist" do
       branch.update_attributes(:pr_title => "[WIP] #{branch.pr_title}")
 
-      expect(github_service).to receive(:add_issue_labels).with(branch.pr_number, "wip")
+      expect(NewGithubService).to receive(:add_labels_to_an_issue).with(branch.repo.name, branch.pr_number, ["wip"])
 
       described_class.new.perform(branch.id)
     end

--- a/spec/workers/pull_request_monitor_spec.rb
+++ b/spec/workers/pull_request_monitor_spec.rb
@@ -2,7 +2,6 @@ describe PullRequestMonitor do
   describe "#process_repo" do
     let(:repo)   { create(:repo) }
 
-    let(:github) { stub_github_service }
     let(:github_pr_head_repo) { double("Github repo", :html_url => "https://github.com/SomeUser/some_repo") }
     let(:github_pr) do
       double("Github PR",
@@ -36,7 +35,7 @@ describe PullRequestMonitor do
     end
 
     it "with Github PRs" do
-      stub_github_prs(github, github_pr)
+      stub_github_prs(github_pr)
       stub_git_service
 
       expect(repo).to receive(:synchronize_pr_branches).with([{
@@ -54,7 +53,7 @@ describe PullRequestMonitor do
       let(:github_pr_head_repo) { nil }
 
       it "creates a PR branch" do
-        stub_github_prs(github, github_pr)
+        stub_github_prs(github_pr)
         stub_git_service
 
         expect(repo).to receive(:synchronize_pr_branches).with([{
@@ -70,7 +69,7 @@ describe PullRequestMonitor do
     end
 
     it "when there are no Github PRs" do
-      stub_github_prs(github, [])
+      stub_github_prs([])
       stub_git_service
 
       expect(repo).to receive(:synchronize_pr_branches).with([]).and_call_original


### PR DESCRIPTION
Introduces a simpler, betterer Github service class implemented with Octokit.

It uses a singleton pattern just like Octokit and most other such gems, and opts out of the service 'call' pattern we've been doing, as discussed at length. Rewriting sections to use this wrapper was stupid easy and straightfoward. Core functionality from the original GithubService was added (but renamed, to feel more natural with Octokit's like-methods).

I also found it easy to use over my previous OctokitWrappers implementation, so I'll be removing that one in favor of this, as well as removing the current GithubService and renaming this one, in a future PR.

Although low priority, I suggest that we do the other services in this pattern except for GitService. MiniGit is a special little snowflake and the thread safety must be maintained.