### PR TITLE
Issue mover

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,37 @@ its own line, in the form `@miq-bot command params`.  Available commands are
 below.  Any command can also be pluralized, where sensible, or have the
 underscores replaced with hyphens.
 
-- `add_label`: Add one or more labels to an issue.  Multiple labels should be
-  comma-separated.  e.g. `@miq-bot add_label label1, label2, label3`
-- `remove_label` (or `rm_label`): Remove one or more labels to an issue.
-  Multiple labels should be comma-separated.  e.g.
-  `@miq-bot remove_label label1, label2, label3`
-- `assign`: Assign the issue to the specified user.  The leading `@` for the
-  user is optional.  The user must be in the Assignees list.  e.g.
-  `@miq-bot assign @user`
-- `set_milestone`: Set the specified milestone on the issue. Do not wrap the
-  milestone in quotes.  e.g. `@miq-bot set_milestone Sprint 27`
+- **`add_label label1[, label2]`**  
+  Add one or more labels to an issue.  Multiple labels should be
+  comma-separated.
+
+  Example: `@miq-bot add_labels label1, label2`
+
+- **`remove_label label1[, label2]`**  
+  Remove one or more labels to an issue. Multiple labels should be comma-separated.
+
+  Example: `@miq-bot remove_label wontfix`
+
+- **`assign [@]user`**  
+  Assign the issue to the specified user.  The leading `@` for the
+  user is optional.  The user must be in the Assignees list.
+
+  Example: `@miq-bot assign @user`
+
+- **`set_milestone milestone_name`**  
+  Set the specified milestone on the issue. Do not wrap the
+  milestone in quotes.
+
+  Example: `@miq-bot set_milestone Sprint 27`
+
+- **`move_issue [organization_name/]repo_name`**  
+  Moves the issue to the specified repo. The bot will open a new issue with
+  your original title and description and close the current one. Useful for
+  reorganizing issues opened on the core ManageIQ/manageiq repo to a more
+  appropriate project (a provider or other ManageIQ plugin). The repository
+  being moved to must be under the same organization as the issue being moved.
+
+  Example: `@miq-bot move_issue manageiq-providers-amazon`
 
 ## Development
 

--- a/lib/github_service/commands/move_issue.rb
+++ b/lib/github_service/commands/move_issue.rb
@@ -1,0 +1,53 @@
+module GithubService
+  module Commands
+    class MoveIssue < Base
+      restrict_to :organization
+
+      private
+
+      def _execute(issuer:, value:)
+        @dest_organization_name, @dest_repo_name = value.split("/", 2).unshift(issue.organization_name).last(2)
+        @dest_fq_repo_name = "#{@dest_organization_name}/#{@dest_repo_name}"
+
+        validate
+
+        if errors.present?
+          issue.add_comment("@#{issuer} :x: `move_issue` failed. #{errors.to_sentence.capitalize}.")
+        else
+          new_issue = GithubService.create_issue(@dest_fq_repo_name, issue.title, new_issue_body)
+          issue.add_comment("This issue has been moved to #{new_issue.html_url}")
+          GithubService.close_issue(issue.fq_repo_name, issue.number)
+        end
+      end
+
+      def errors
+        @errors ||= []
+      end
+
+      def validate
+        if issue.repo_name.downcase == @dest_repo_name.downcase
+          errors << "issue already exists on the '#{issue.repo_name}' repository"
+        end
+        if issue.pull_request?
+          errors << "a pull request cannot be moved"
+        end
+        if issue.organization_name.downcase != @dest_organization_name.downcase
+          errors << "cannot move issue to repository outside of the #{issue.organization_name} organization"
+        end
+        unless GithubService.repository?(@dest_fq_repo_name)
+          errors << "repository does not exist or is unreachable"
+        end
+      end
+
+      def new_issue_body
+        <<-EOS
+#{issue.body}
+
+---
+
+*This issue was moved to this repository from #{issue.html_url}, originally opened by @#{issue.author}*
+        EOS
+      end
+    end
+  end
+end

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -63,6 +63,10 @@ module GithubService
       user.login
     end
 
+    def pull_request?
+      respond_to?(:pull_request)
+    end
+
     # Overrides Octokit response key
     # We manage this ourselves for the life of the issue object to avoid making
     # extra API calls.


### PR DESCRIPTION
**REQUIRES #329; merge that first**

Closes #258

@Fryguy Please review

cc/ @blomquisg 

Move success (original issue):
![](http://screenshots.chrisarcand.com/permxixo5.jpg)

Move success (new issue):
![](http://screenshots.chrisarcand.com/permp4zrr.jpg)

Trying to move a pull request:
![](http://screenshots.chrisarcand.com/permpc8g3.jpg)

Trying to move an issue and you're not part of the org:
![](http://screenshots.chrisarcand.com/perm6am08.jpg)

With several qualifications, errors are combined to human readable sentences so people don't hit their head against the wall over and over. For example, trying to move a pull request AND trying to specify a repo outside of the issue's organization:
![](http://screenshots.chrisarcand.com/aaej9.jpg)
