### PR TITLE
Add graphics_labeler for labeling PRs with image changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ underscores replaced with hyphens.
       enabled_repos: ["miq-test/sandbox"]
 
     # Optional; leave blank to disable
+    graphics_labeler:
+      enabled_repos: ["miq-test/sandbox"]
+
+    # Optional; leave blank to disable
     github_notification_monitor:
       repo_names: ["miq-test/sandbox"]
 

--- a/app/workers/commit_monitor_handlers/commit_range/graphics_labeler.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/graphics_labeler.rb
@@ -1,0 +1,41 @@
+class CommitMonitorHandlers::CommitRange::GraphicsLabeler
+  include Sidekiq::Worker
+  sidekiq_options :queue => :miq_bot
+
+  include BranchWorkerMixin
+
+  LABEL = "graphics".freeze
+
+  def self.handled_branch_modes
+    [:pr]
+  end
+
+  def perform(branch_id, _new_commits)
+    return unless find_branch(branch_id, :pr)
+    return unless verify_branch_enabled
+
+    process_branch
+  end
+
+  private
+
+  def process_branch
+    apply_label if graphics_changes_in_diff?
+  end
+
+  def graphics_changes_in_diff?
+    branch.git_service.diff.new_files.any? { |file| graphics_changes?(file) }
+  rescue Rugged::IndexError
+    # Failed to create merge index, no point in trying
+    return false
+  end
+
+  def graphics_changes?(file)
+    file.to_s.downcase =~ /\.(png|svg|jpe?g|gif)$/
+  end
+
+  def apply_label
+    logger.info("Updating PR #{pr_number} with label #{LABEL.inspect}.")
+    GithubService.add_labels_to_an_issue(fq_repo_name, pr_number, [LABEL])
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,8 @@ grafana:
 diff_content_checker: {}
 gem_changes_labeler:
   enabled_repos: []
+graphics_labeler:
+  enabled_repos: []
 github_notification_monitor:
   repo_names: []
 merge_target_titler:

--- a/spec/workers/commit_monitor_handlers/commit_range/graphics_labeler_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/graphics_labeler_spec.rb
@@ -1,0 +1,30 @@
+describe CommitMonitorHandlers::CommitRange::GraphicsLabeler do
+  let(:branch)         { create(:pr_branch) }
+  let(:git_service)    { double("GitService", :diff => double("RuggedDiff", :new_files => new_files)) }
+
+  before do
+    stub_sidekiq_logger
+    stub_settings(:graphics_labeler => {:enabled_repos => [branch.repo.name]})
+    expect_any_instance_of(Branch).to receive(:git_service).and_return(git_service)
+  end
+
+  context "when there are image changes" do
+    let(:new_files) { ["image.png", "some/other/file.rb"] }
+
+    it "adds a label to the PR" do
+      expect(GithubService).to receive(:add_labels_to_an_issue).with(branch.repo.name, branch.pr_number, ["graphics"])
+
+      described_class.new.perform(branch.id, nil)
+    end
+  end
+
+  context "where there are no image changes" do
+    let(:new_files) { ["some/other/file.rb"] }
+
+    it "does not add a label to the PR" do
+      expect(GithubService).to_not receive(:add_labels_to_an_issue)
+
+      described_class.new.perform(branch.id, nil)
+    end
+  end
+end


### PR DESCRIPTION
We would like to use this for detecting image changes in the `ui-classic` repo. FYI @epwinchell