### PR TITLE
Replace blob getter with a content getter

### DIFF
--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -7,12 +7,8 @@ module GitService
       @branch = branch
     end
 
-    def blob_at(path) # Rugged::Blob object for a given file path on this branch
-      blob_data = tip_tree.path(path)
-      blob = Rugged::Blob.lookup(rugged_repo, blob_data[:oid])
-      (blob.type == :blob) ? blob : nil
-    rescue Rugged::TreeError
-      nil
+    def content_at(path)
+      blob_at(path).try(:content)
     end
 
     def diff
@@ -64,6 +60,14 @@ module GitService
 
     def merge_target_ref_name
       "refs/remotes/origin/#{branch.merge_target}"
+    end
+
+    def blob_at(path) # Rugged::Blob object for a given file path on this branch
+      blob_data = tip_tree.path(path)
+      blob = Rugged::Blob.lookup(rugged_repo, blob_data[:oid])
+      blob.type == :blob ? blob : nil
+    rescue Rugged::TreeError
+      nil
     end
 
     def rugged_repo

--- a/lib/linter/base.rb
+++ b/lib/linter/base.rb
@@ -49,11 +49,12 @@ module Linter
     end
 
     def extract_file(path, destination_dir)
-      blob = branch_service.blob_at(path)
-      return false unless blob
+      content = branch_service.content_at(path)
+      return false unless content
+
       temp_file = File.join(destination_dir, path)
       FileUtils.mkdir_p(File.dirname(temp_file))
-      File.write(temp_file, blob.content.to_s, :mode => "wb") # To prevent Encoding::UndefinedConversionError: "\xD0" from ASCII-8BIT to UTF-8
+      File.write(temp_file, content, :mode => "wb") # To prevent Encoding::UndefinedConversionError: "\xD0" from ASCII-8BIT to UTF-8
       true
     end
 


### PR DESCRIPTION
@chrisarcand or @bdunne Please review.

This is a minor refactor, which I need for enable_disable support, but could be pulled out into its own PR.  Basically, I can't see why a caller would ever want the raw Rugged::Blob object versus just its content.  So, this changes the interface to just get the content.  The only current caller also just wants the content.