### PR TITLE
Standardize on enable/disable of repos across all workers

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -14,8 +14,6 @@ class Branch < ActiveRecord::Base
 
   after_initialize(:unless => :commit_uri) { self.commit_uri = self.class.github_commit_uri(repo.try(:name)) }
 
-  delegate :enabled_for?, :to => :repo
-
   scope :regular_branches, -> { where(:pull_request => [false, nil]) }
 
   def self.with_branch_or_pr_number(n)
@@ -87,6 +85,10 @@ class Branch < ActiveRecord::Base
 
   def fq_repo_name
     repo.name
+  end
+
+  def fq_branch_name
+    "#{fq_repo_name}@#{name}"
   end
 
   def git_service

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -61,12 +61,6 @@ class Repo < ActiveRecord::Base
     yield Travis::Repository.find(name)
   end
 
-  def enabled_for?(checker)
-    Array(Settings.public_send(checker).enabled_repos).each_with_object([]) { |value, values|
-      values << (value.kind_of?(Array) ? value.first.to_s : value)
-    }.include?(name)
-  end
-
   def branch_names
     branches.collect(&:name)
   end

--- a/app/workers/commit_monitor_handlers/batch/github_pr_commenter/diff_content_checker.rb
+++ b/app/workers/commit_monitor_handlers/batch/github_pr_commenter/diff_content_checker.rb
@@ -36,7 +36,7 @@ module CommitMonitorHandlers::Batch
 
     def check_line(line, patch)
       file_path = patch.delta.new_file[:path]
-      Settings.diff_content_checker.each do |offender, options|
+      Settings.diff_content_checker.offenses.each do |offender, options|
         next if options.except.try(:any?) { |except| file_path.start_with?(except) }
 
         regexp = options.type == :regexp ? Regexp.new(offender.to_s) : /\b#{Regexp.escape(offender.to_s)}\b/i

--- a/app/workers/commit_monitor_handlers/commit/pivotal_pr_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit/pivotal_pr_checker.rb
@@ -14,7 +14,6 @@ module CommitMonitorHandlers
 
       def perform(branch_id, commit, commit_details)
         return unless find_branch(branch_id, :pr)
-        return unless verify_branch_enabled
 
         @commit  = commit
         @message = commit_details["message"]

--- a/app/workers/commit_monitor_handlers/commit_range/path_based_labeler.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/path_based_labeler.rb
@@ -10,7 +10,6 @@ class CommitMonitorHandlers::CommitRange::PathBasedLabeler
 
   def perform(branch_id, _new_commits)
     return unless find_branch(branch_id, :pr)
-    return unless verify_branch_enabled
 
     process_branch
   end
@@ -29,6 +28,6 @@ class CommitMonitorHandlers::CommitRange::PathBasedLabeler
   end
 
   def label_rules
-    Settings.path_based_labeler.enabled_repos[fq_repo_name]
+    Settings.path_based_labeler.rules[fq_repo_name]
   end
 end

--- a/app/workers/github_notification_monitor_worker.rb
+++ b/app/workers/github_notification_monitor_worker.rb
@@ -15,16 +15,11 @@ class GithubNotificationMonitorWorker
     end
   end
 
-  private
-
   def process_repos
-    repo_names = Array(Settings.github_notification_monitor.repo_names)
-    Repo.where(:name => repo_names).each do |repo|
-      process_notifications(repo)
-    end
+    enabled_repos.each { |repo| process_repo(repo) }
   end
 
-  def process_notifications(repo)
+  def process_repo(repo)
     GithubNotificationMonitor.new(repo.name).process_notifications
   rescue => err
     logger.error err.message

--- a/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
+++ b/app/workers/pull_request_monitor_handlers/merge_target_titler.rb
@@ -6,7 +6,6 @@ class PullRequestMonitorHandlers::MergeTargetTitler
 
   def perform(branch_id)
     return unless find_branch(branch_id, :pr)
-    return unless verify_branch_enabled
 
     process_branch
   end

--- a/app/workers/pull_request_monitor_handlers/wip_labeler.rb
+++ b/app/workers/pull_request_monitor_handlers/wip_labeler.rb
@@ -8,7 +8,6 @@ class PullRequestMonitorHandlers::WipLabeler
 
   def perform(branch_id)
     return unless find_branch(branch_id, :pr)
-    return unless verify_branch_enabled
 
     process_branch
   end

--- a/app/workers/schedulers/code_analyzer.rb
+++ b/app/workers/schedulers/code_analyzer.rb
@@ -9,17 +9,11 @@ module Schedulers
     include SidekiqWorkerMixin
 
     def perform
-      Repo.where(:name => fq_repo_names).each do |repo|
+      enabled_repos.each do |repo|
         repo.branches.regular_branches.pluck(:id).each do |branch_id|
           CommitMonitorHandlers::Branch::CodeAnalyzer.perform_async(branch_id)
         end
       end
-    end
-
-    private
-
-    def fq_repo_names
-      Settings.code_analyzer.enabled_repos
     end
   end
 end

--- a/app/workers/schedulers/stale_issue_marker.rb
+++ b/app/workers/schedulers/stale_issue_marker.rb
@@ -9,15 +9,7 @@ module Schedulers
     include SidekiqWorkerMixin
 
     def perform
-      fq_repo_names.each do |name|
-        ::StaleIssueMarker.perform_async(name)
-      end
-    end
-
-    private
-
-    def fq_repo_names
-      Settings.stale_issue_marker.enabled_repos
+      enabled_repo_names.each { |r| ::StaleIssueMarker.perform_async(r) }
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,18 +20,11 @@ grafana:
   url:
 
 # Worker settings
-code_analyzer:
-  enabled_repos: []
-diff_content_checker: {}
-github_notification_monitor:
-  repo_names: []
+diff_content_checker:
+  offenses: {}
 merge_target_titler:
-  enabled_repos: []
+  included_repos: []
 path_based_labeler:
-  enabled_repos: {}
-pivotal_pr_checker:
-  enabled_repos: []
-stale_issue_marker:
-  enabled_repos: []
-wip_labeler:
-  enabled_repos: []
+  rules: {}
+travis_build_killer:
+  included_repos: []

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,8 @@
+# In test, turn everything on by default
+#   NOTE: Using empty string is a HACK until we can get
+#   https://github.com/danielsdeleo/deep_merge/pull/33 released via the
+#   config gem.
+merge_target_titler:
+  included_repos: ''
+travis_build_killer:
+  included_repos: ''

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -168,4 +168,12 @@ describe Branch do
   it "#write_github_comment raises on non-pr branches" do
     expect { branch.write_github_comment("<test /> blah") }.to raise_error(ArgumentError)
   end
+
+  it "#fq_repo_name" do
+    expect(branch.fq_repo_name).to eq("test-user/test-repo")
+  end
+
+  it "#fq_branch_name" do
+    expect(branch.fq_branch_name).to eq("test-user/test-repo@test-branch")
+  end
 end

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -196,34 +196,4 @@ describe Repo do
       expect { repo.synchronize_pr_branches([]) }.to_not raise_error
     end
   end
-
-  describe "#enabled_for?" do
-    subject(:repo) { build(:repo, :name => "foo/bar") }
-
-    let(:settings) do
-      { "checker_1" => { "enabled_repos" => { "foo/bar" => [{ "pattern" => "ansible_tower", "label" => "bug" }] }},
-        "checker_2" => { "enabled_repos" => {} },
-        "checker_3" => { "enabled_repos" => ["foo/bar"] },
-        "checker_4" => { "enabled_repos" => ["not/theone"] },
-        "checker_5" => { "enabled_repos" => "foo/bar" },
-        "checker_6" => { "enabled_repos" => "not/theone" } }
-    end
-
-    before { stub_settings(settings) }
-
-    it "handles hashes" do
-      expect(repo.enabled_for?("checker_1")).to be_truthy
-      expect(repo.enabled_for?("checker_2")).to be_falsey
-    end
-
-    it "handles arrays" do
-      expect(repo.enabled_for?("checker_3")).to be_truthy
-      expect(repo.enabled_for?("checker_4")).to be_falsey
-    end
-
-    it "handles strings" do
-      expect(repo.enabled_for?("checker_5")).to be_truthy
-      expect(repo.enabled_for?("checker_6")).to be_falsey
-    end
-  end
 end

--- a/spec/workers/commit_monitor_handlers/batch/github_pr_commenter/diff_content_checker_spec.rb
+++ b/spec/workers/commit_monitor_handlers/batch/github_pr_commenter/diff_content_checker_spec.rb
@@ -26,7 +26,7 @@ describe CommitMonitorHandlers::Batch::GithubPrCommenter::DiffContentChecker do
 
   context "with offending word" do
     it "with one offender in the diff" do
-      stub_settings(:diff_content_checker => {"puts" => {:severity => :error}})
+      stub_settings(:diff_content_checker => {"offenses" => {"puts" => {:severity => :error}}})
       described_class.new.perform(batch_entry.id, branch.id, nil)
 
       batch_entry.reload
@@ -39,7 +39,7 @@ describe CommitMonitorHandlers::Batch::GithubPrCommenter::DiffContentChecker do
     end
 
     it "with one offender in the diff of an ignored file" do
-      stub_settings(:diff_content_checker => {"puts" => {:except => ["tools/"], :severity => :error}})
+      stub_settings(:diff_content_checker => {"offenses" => {"puts" => {:except => ["tools/"], :severity => :error}}})
       described_class.new.perform(batch_entry.id, branch.id, nil)
 
       batch_entry.reload
@@ -50,7 +50,7 @@ describe CommitMonitorHandlers::Batch::GithubPrCommenter::DiffContentChecker do
       let(:content_2) { "inputs = variable" }
 
       it do
-        stub_settings(:diff_content_checker => {"puts" => {:severity => :error}})
+        stub_settings(:diff_content_checker => {"offenses" => {"puts" => {:severity => :error}}})
         described_class.new.perform(batch_entry.id, branch.id, nil)
 
         batch_entry.reload
@@ -61,7 +61,7 @@ describe CommitMonitorHandlers::Batch::GithubPrCommenter::DiffContentChecker do
 
   context "with offending regex" do
     it "with one offender in the diff" do
-      stub_settings(:diff_content_checker => {"^def" => {:severity => :error, :type => :regexp}})
+      stub_settings(:diff_content_checker => {"offenses" => {"^def" => {:severity => :error, :type => :regexp}}})
       described_class.new.perform(batch_entry.id, branch.id, nil)
 
       batch_entry.reload

--- a/spec/workers/commit_monitor_handlers/commit_range/path_based_labeler_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/path_based_labeler_spec.rb
@@ -4,8 +4,8 @@ describe CommitMonitorHandlers::CommitRange::PathBasedLabeler do
   let(:branch)         { create(:pr_branch) }
   let(:git_service)    { double("GitService", :diff => double("RuggedDiff", :new_files => new_files)) }
   let(:settings) do
-    { "path_based_labeler" => { "enabled_repos" => { branch.repo.name => [{ "regex" => /(?:Gemfile|Gemfile\.lock|\.gemspec)\z/, "label" => "gem changes" },
-                                                                          { "regex" => /db\/migrate.+\.rb\z/, "label" => "sql migration" }] } } }
+    { "path_based_labeler" => { "rules" => { branch.repo.name => [{ "regex" => /(?:Gemfile|Gemfile\.lock|\.gemspec)\z/, "label" => "gem changes" },
+                                                                  { "regex" => /db\/migrate.+\.rb\z/, "label" => "sql migration" }] } } }
   end
 
   before do

--- a/spec/workers/pull_request_monitor_spec.rb
+++ b/spec/workers/pull_request_monitor_spec.rb
@@ -27,7 +27,7 @@ describe PullRequestMonitor do
     end
 
     it "ignores a repo that can't have PRs (because of no upstream_user)" do
-      repo.update_attributes(:name => "foo")
+      repo.update_attributes!(:name => "foo")
 
       expect(repo).to_not receive(:synchronize_pr_branches)
 


### PR DESCRIPTION
This PRs standardizes on repo names in the settings.yml for all workers and supports them in any worker.

The way the settings.yml will work is to specify either included_repos, excluded_repos, or nothing.

```yaml
worker1:  # Will run in all repos

worker2:  # Will only run in the specified repos
  included_repos:
  - "org1/repo1"
  - "org2/repo12"

worker3:  # Will run in all repos except the specified repos
  excluded_repos:
  - "org1/repo1"
  - "org2/repo12"

worker4:  # Will raise an exception, since you should not specify both
  included_repos:
  - "org1/repo1"
  excluded_repos:
  - "org2/repo12"

worker5:  # Effectively disables the worker
  included_repos: []
```

TODO:

- [x] Specs.
- [x] Determine if find_branch should also check for enablement.  It's not necessary because the workers will not be queued, but could potentially be queued outside of the workflow.
- [x] Update the default settings.yml for each worker with sensible defaults (i.e. default to all repos, or default to no repos)
- Support enable/disable for specific linters. (deferring to a separate PR)
- Support yaml references to avoid a lot of copy/paste in the yaml.  (deferring to a separate PR)
    Example:

    ```yaml
    core_repos: &core_repos
    - ManageIQ/manageiq
    - ManageIQ/manageiq-ui-classic
    - ManageIQ/manageiq-ui-service
    - ManageIQ/manageiq-providers-amazon
    ... # 10 more repos

    worker1:
      included_repos:
      - *core_repos
    worker2:
      included_repos:
      - *core_repos
      - ManageIQ/additional_repo
    ```