### PR TITLE
Add dev helper method for sidekiq processing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,9 @@ module MiqBot
 
     config.eager_load_paths << Rails.root.join("app/workers/concerns")
     config.eager_load_paths << Rails.root.join("lib")
+
+    console do
+      TOPLEVEL_BINDING.eval('self').extend(ConsoleMethods)
+    end
   end
 end

--- a/lib/console_methods.rb
+++ b/lib/console_methods.rb
@@ -1,0 +1,19 @@
+module ConsoleMethods
+  def simulate_sidekiq(*queue_names, run_once: false)
+    run = true
+    while run do
+      queue_names.each do |queue_name|
+        puts "[#{Time.now}] Processing '#{queue_name}'..."
+        Sidekiq::Queue.new(queue_name).each do |job|
+          worker = job['class'].constantize
+          args = job['args']
+          puts "\nProcessing #{worker} with args: #{args}"
+          worker.new.perform(*job['args'])
+          job.delete
+        end
+      end
+      run = false if run_once
+      sleep(2)
+    end
+  end
+end


### PR DESCRIPTION
To my surprise, Sidekiq doesn't provide a way to process a queue in the console.

That's sort of annoying for testing stuff locally, because it takes forever to let the application process things fully. For example, to test a pull request handler:

* Start up all processes with foreman
* Push a commit to the test repo
* Wait for the pull request monitor job to enqueue and process (5 minutes, potentially)
* Wait for the github notification monitor to enqueue and process (5 minutes, potentially)
* Wait for workers enqueued from the GHNM to process (???)

Yuge waste of time. I sit staring at the screen waiting for the bot to act alive or get distracted by Twitter et al waiting, etc.

On top of that, because of the separate Sidekiq processes, debugging is sort of annoying because you don't have an easy handle to a debugging session in a seperate process.
To combat this, you can use something like pry-remote (remote sessions via dRB) but that's also annoying as the other processes won't wait for you.

TLDR: Here's a way to simulate processing of multiple sidekiq queues, sequentially. Now to fake an entire bot run on a pull request:

```
> PullRequestMonitor.new.perform && CommitMonitor.new.perform && simulate_sidekiq('miq_bot', 'miq_bot_glacial', :run_once => true)
```