### PR TITLE
Add close_issue command

### DIFF
--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -1,7 +1,9 @@
 module GithubService
   module Commands
     class AddLabel < Base
-      def execute!(issuer:, value:)
+      private
+
+      def _execute(issuer:, value:)
         valid, invalid = extract_label_names(value)
 
         if invalid.any?
@@ -15,8 +17,6 @@ module GithubService
           issue.add_labels(valid)
         end
       end
-
-      private
 
       def extract_label_names(value)
         label_names = value.split(",").map { |label| label.strip.downcase }

--- a/lib/github_service/commands/assign.rb
+++ b/lib/github_service/commands/assign.rb
@@ -1,7 +1,9 @@
 module GithubService
   module Commands
     class Assign < Base
-      def execute!(issuer:, value:)
+      private
+
+      def _execute(issuer:, value:)
         user = value.strip.delete('@')
 
         if valid_assignee?(user)
@@ -10,8 +12,6 @@ module GithubService
           issue.add_comment("@#{issuer} '#{user}' is an invalid assignee, ignoring...")
         end
       end
-
-      private
 
       def valid_assignee?(user)
         # First reload the cache if it's an invalid assignee

--- a/lib/github_service/commands/base.rb
+++ b/lib/github_service/commands/base.rb
@@ -1,13 +1,6 @@
 module GithubService
   module Commands
     class Base
-      module CommandMethods
-        def register_as(command_name)
-          CommandDispatcher.register_command(command_name, self)
-        end
-        alias alias_as register_as
-      end
-
       class << self
         def inherited(subclass)
           subclass.extend(CommandMethods)
@@ -15,11 +8,9 @@ module GithubService
           class_name = subclass.to_s.demodulize
           subclass.register_as(class_name.underscore)
         end
-
-        def execute!(*args)
-          new.execute!(*args)
-        end
       end
+
+      class_attribute :restriction
 
       attr_reader :issue
 
@@ -27,9 +18,59 @@ module GithubService
         @issue = issue
       end
 
-      def execute!(command_issuer:, value:)
+      ##
+      # Public interface to Command classes
+      # Subclasses of Commands::Base should implement #_execute with
+      # the following keyword arguments:
+      #
+      # issuer - The username of the user that issued the command
+      # value -  The value of the command given
+      #
+      # No callers should ever use _execute directly, using execute! instead.
+      #
+      def execute!(issuer:, value:)
+        if user_permitted?(issuer)
+          _execute(:issuer => issuer, :value => value)
+        end
+      end
+
+      private
+
+      def _execute
         raise NotImplementedError
       end
+
+      def user_permitted?(issuer)
+        case self.class.restriction
+        when nil
+          true
+        when :organization
+          if GithubService.organization_member?(issue.organization_name, issuer)
+            true
+          else
+            issue.add_comment("@#{issuer} Only members of the #{issue.organization_name} organization may use this command.")
+            false
+          end
+        end
+      end
+
+      VALID_RESTRICTIONS = [:organization].freeze
+
+      module CommandMethods
+        def register_as(command_name)
+          CommandDispatcher.register_command(command_name, self)
+        end
+        alias alias_as register_as
+
+        def restrict_to(restriction)
+          unless VALID_RESTRICTIONS.include?(restriction)
+            raise RestrictionError, "'#{restriction}' is not a valid restriction"
+          end
+          self.restriction = restriction
+        end
+      end
+
+      RestrictionError = Class.new(StandardError)
     end
   end
 end

--- a/lib/github_service/commands/close_issue.rb
+++ b/lib/github_service/commands/close_issue.rb
@@ -1,0 +1,17 @@
+module GithubService
+  module Commands
+    class CloseIssue < Base
+      restrict_to :organization
+
+      private
+
+      def _execute(issuer:, value:)
+        if issue.pull_request? && issuer != issue.author
+          issue.add_comment("@#{issuer} Only @#{issue.author} or a committer can close this pull request.")
+        else
+          GithubService.close_issue(issue.fq_repo_name, issue.number)
+        end
+      end
+    end
+  end
+end

--- a/lib/github_service/commands/remove_label.rb
+++ b/lib/github_service/commands/remove_label.rb
@@ -3,7 +3,9 @@ module GithubService
     class RemoveLabel < Base
       alias_as 'rm_label'
 
-      def execute!(issuer:, value:)
+      private
+
+      def _execute(issuer:, value:)
         valid, invalid = extract_label_names(value)
 
         if invalid.any?
@@ -16,8 +18,6 @@ module GithubService
           issue.remove_label(l) if issue.applied_label?(l)
         end
       end
-
-      private
 
       def extract_label_names(value)
         label_names = value.split(",").map { |label| label.strip.downcase }

--- a/lib/github_service/commands/set_milestone.rb
+++ b/lib/github_service/commands/set_milestone.rb
@@ -1,7 +1,9 @@
 module GithubService
   module Commands
     class SetMilestone < Base
-      def execute!(issuer:, value:)
+      private
+
+      def _execute(issuer:, value:)
         milestone = value.strip
 
         if valid_milestone?(milestone)
@@ -10,8 +12,6 @@ module GithubService
           issue.add_comment("@#{issuer} Milestone #{milestone} is not recognized, ignoring...")
         end
       end
-
-      private
 
       def valid_milestone?(milestone)
         # First reload the cache if it's an invalid milestone

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -63,6 +63,10 @@ module GithubService
       user.login
     end
 
+    def pull_request?
+      respond_to?(:pull_request)
+    end
+
     # Overrides Octokit response key
     # We manage this ourselves for the life of the issue object to avoid making
     # extra API calls.

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -74,6 +74,14 @@ module GithubService
       @fq_repo_name ||= repository_url.match(/repos\/([^\/]+\/[^\/]+)\z/)[1]
     end
 
+    def organization_name
+      @organization_name ||= fq_repo_name.split("/")[0]
+    end
+
+    def repo_name
+      @repo_name ||= fq_repo_name.split("/")[1]
+    end
+
     private
 
     def wipify_title


### PR DESCRIPTION
**REQUIRES #329; merge that first**

Closes #191 

Adds a command for organization members to close issues without commit access.

* Some dispatcher parsing had to be reworked because the previous implementation didn't allow for commands with no parameters.
* If the issue is a pull request, only the author of the pull request or a committer (manually) can close it. I don't like the idea of just anyone being able to close the door on contributions from other contributors.