### PR TITLE
Stale issue/PR marker

### DIFF
--- a/app/workers/schedulers/stale_issue_marker.rb
+++ b/app/workers/schedulers/stale_issue_marker.rb
@@ -1,0 +1,23 @@
+module Schedulers
+  class StaleIssueMarker
+    include Sidekiq::Worker
+    sidekiq_options :queue => :miq_bot_glacial, :retry => false
+
+    include Sidetiq::Schedulable
+    recurrence { weekly.day(:saturday) }
+
+    include SidekiqWorkerMixin
+
+    def perform
+      fq_repo_names.each do |name|
+        ::StaleIssueMarker.perform_async(name)
+      end
+    end
+
+    private
+
+    def fq_repo_names
+      Settings.stale_issue_marker.enabled_repos
+    end
+  end
+end

--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -8,15 +8,15 @@ class StaleIssueMarker
   PINNED_LABELS    = ['pinned'].freeze
 
   STALE_LABEL_NAME = 'stale'.freeze
-  STALE_ISSUE_MESSAGE = <<-EOS
-This issue has been automatically marked as stale because it has not been updated for at least 3 months.
+  STALE_ISSUE_MESSAGE = <<-EOS.freeze
+This issue has been automatically marked as stale because it has not been updated for at least 6 months.
 
 If you can still reproduce this issue on the current release or on `master`, please reply with all of the information you have about it in order to keep the issue open.
 
 Thank you for all your contributions!
   EOS
-  CLOSABLE_PR_MESSAGE = <<-EOS
-This pull request has been automatically closed because it has not been updated for at least 3 months.
+  CLOSABLE_PR_MESSAGE = <<-EOS.freeze
+This pull request has been automatically closed because it has not been updated for at least 6 months.
 
 Feel free to reopen this pull request if these changes are still valid.
 
@@ -58,7 +58,7 @@ Thank you for all your contributions!
   private
 
   def stale_date
-    @stale_date ||= 3.months.ago
+    @stale_date ||= 6.months.ago
   end
 
   def stale_issues

--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -1,0 +1,71 @@
+class StaleIssueMarker
+  include Sidekiq::Worker
+  sidekiq_options :queue => :miq_bot_glacial, :retry => false
+
+  include SidekiqWorkerMixin
+
+  # If an issue/pr has any of these labels, it will not be marked as stale or closed
+  PINNED_LABELS    = ['pinned'].freeze
+
+  STALE_LABEL_NAME = 'stale'.freeze
+  STALE_ISSUE_MESSAGE = <<-EOS
+This issue has been automatically marked as stale because it has not been updated for at least 3 months.
+
+If you can still reproduce this issue on the current release or on `master`, please reply with all of the information you have about it in order to keep the issue open.
+
+Thank you for all your contributions!
+  EOS
+  CLOSABLE_PR_MESSAGE = <<-EOS
+This pull request has been automatically closed because it has not been updated for at least 3 months.
+
+Feel free to reopen this pull request if these changes are still valid.
+
+Thank you for all your contributions!
+  EOS
+
+  attr_reader :fq_repo_name
+
+  def perform(fq_repo_name)
+    @fq_repo_name = fq_repo_name
+    raise "The label #{STALE_LABEL_NAME} does not exist on #{fq_repo_name}" unless GithubService.valid_label?(fq_repo_name, STALE_LABEL_NAME)
+
+    GithubService.issues(fq_repo_name, :state => :open, :sort => :updated, :direction => :asc).each do |issue|
+      pinned = (issue.labels & PINNED_LABELS).present?
+
+      if issue.updated_at < stale_date && !pinned
+        if issue.pull_request?
+          closable_prs << issue
+        else
+          stale_issues << issue
+        end
+      end
+    end
+
+    stale_issues.each do |issue|
+      next if issue.labels.include?(STALE_LABEL_NAME)
+      logger.info("[#{Time.now.utc}] - Marking issue #{fq_repo_name}##{issue.number} as stale")
+      issue.add_labels([STALE_LABEL_NAME])
+      issue.add_comment(STALE_ISSUE_MESSAGE)
+    end
+
+    closable_prs.each do |pr|
+      logger.info("[#{Time.now.utc}] - Closing stale PR #{fq_repo_name}##{pr.number}")
+      GithubService.close_pull_request(pr.fq_repo_name, pr.number)
+      pr.add_comment(CLOSABLE_PR_MESSAGE)
+    end
+  end
+
+  private
+
+  def stale_date
+    @stale_date ||= 3.months.ago
+  end
+
+  def stale_issues
+    @stale_issues ||= []
+  end
+
+  def closable_prs
+    @closable_prs ||= []
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,5 +29,7 @@ path_based_labeler:
   enabled_repos: {}
 pivotal_pr_checker:
   enabled_repos: []
+stale_issue_marker:
+  enabled_repos: []
 wip_labeler:
   enabled_repos: []

--- a/lib/github_service.rb
+++ b/lib/github_service.rb
@@ -37,6 +37,11 @@ module GithubService
       Issue.new(service.issue(*args))
     end
 
+    def list_issues(*args)
+      service.list_issues(*args).map { |issue| Issue.new(issue) }
+    end
+    alias issues list_issues
+
     def issue_comments(*args)
       service.issue_comments(*args).map do |comment|
         IssueComment.new(comment)

--- a/spec/workers/stale_issue_marker_spec.rb
+++ b/spec/workers/stale_issue_marker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StaleIssueMarker do
 
   let(:already_stale_issue) do
     double("already_stale_issue",
-           :updated_at    => 5.months.ago,
+           :updated_at    => 8.months.ago,
            :fq_repo_name  => fq_repo_name,
            :number        => 3,
            :pull_request? => false,
@@ -14,7 +14,7 @@ RSpec.describe StaleIssueMarker do
 
   let(:stale_issue) do
     double("stale_issue",
-           :updated_at    => 4.months.ago,
+           :updated_at    => 7.months.ago,
            :fq_repo_name  => fq_repo_name,
            :number        => 4,
            :pull_request? => false,
@@ -23,7 +23,7 @@ RSpec.describe StaleIssueMarker do
 
   let(:stale_pr) do
     double("stale_pr",
-           :updated_at    => 6.months.ago,
+           :updated_at    => 7.months.ago,
            :fq_repo_name  => fq_repo_name,
            :number        => 2,
            :pull_request? => true,
@@ -71,6 +71,7 @@ RSpec.describe StaleIssueMarker do
       .with(fq_repo_name, :state => :open, :sort => :updated, :direction => :asc)
       .and_return(issues)
     allow(GithubService).to receive(:valid_label?).with(fq_repo_name, "stale").and_return(true)
+    allow(Sidekiq).to receive(:logger).and_return(double(:info => nil))
   end
 
   after do

--- a/spec/workers/stale_issue_marker_spec.rb
+++ b/spec/workers/stale_issue_marker_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+
+RSpec.describe StaleIssueMarker do
+  let(:fq_repo_name) { "foo/bar" }
+
+  let(:already_stale_issue) do
+    double("already_stale_issue",
+           :updated_at    => 5.months.ago,
+           :fq_repo_name  => fq_repo_name,
+           :number        => 3,
+           :pull_request? => false,
+           :labels        => %w(stale bug))
+  end
+
+  let(:stale_issue) do
+    double("stale_issue",
+           :updated_at    => 4.months.ago,
+           :fq_repo_name  => fq_repo_name,
+           :number        => 4,
+           :pull_request? => false,
+           :labels        => ["bug"])
+  end
+
+  let(:stale_pr) do
+    double("stale_pr",
+           :updated_at    => 6.months.ago,
+           :fq_repo_name  => fq_repo_name,
+           :number        => 2,
+           :pull_request? => true,
+           :labels        => [])
+  end
+
+  let(:fresh_issue) do
+    double("fresh_issue",
+           :updated_at    => 2.months.ago,
+           :fq_repo_name  => fq_repo_name,
+           :number        => 5,
+           :pull_request? => false,
+           :labels        => ["bug"])
+  end
+
+  let(:fresh_pr) do
+    double("fresh_pr",
+           :updated_at    => 2.months.ago,
+           :fq_repo_name  => fq_repo_name,
+           :number        => 6,
+           :pull_request? => true,
+           :labels        => ["bug"])
+  end
+
+  let(:stale_but_pinned_issue) do
+    double("stale_but_pinned_issue",
+           :updated_at    => 9.months.ago,
+           :fq_repo_name  => fq_repo_name,
+           :number        => 1,
+           :pull_request? => true,
+           :labels        => %w(bug pinned))
+  end
+
+  let(:issues) do
+    [already_stale_issue,
+     stale_issue,
+     stale_pr,
+     fresh_issue,
+     fresh_pr,
+     stale_but_pinned_issue]
+  end
+
+  before do
+    allow(GithubService).to receive(:issues)
+      .with(fq_repo_name, :state => :open, :sort => :updated, :direction => :asc)
+      .and_return(issues)
+    allow(GithubService).to receive(:valid_label?).with(fq_repo_name, "stale").and_return(true)
+  end
+
+  after do
+    described_class.new.perform(fq_repo_name)
+  end
+
+  it "closes stale PRs and marks stale issues, respecting pins and commenting accordingly" do
+    expect(stale_issue).to receive(:add_labels).with(["stale"])
+    expect(stale_issue).to receive(:add_comment).with(/This issue.*marked as stale/)
+
+    expect(GithubService).to receive(:close_pull_request).with(fq_repo_name, stale_pr.number)
+    expect(stale_pr).to receive(:add_comment).with(/This pull request.*closed/)
+
+    issues.each do |issue|
+      unless issue == stale_issue
+        expect(issue).to_not receive(:add_labels)
+      end
+    end
+
+    issues.each do |issue|
+      unless issue == stale_pr
+        expect(GithubService).to_not receive(:close_pull_request).with(issue.number)
+      end
+    end
+
+    issues.each do |issue|
+      unless [stale_pr, stale_issue].include?(issue)
+        expect(issue).to_not receive(:add_comment)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Inspired by rails-bot (which in this case is nothing more than [a manual script](https://github.com/rafaelfranca/rails-tools/blob/master/bin/mark_stale_issues) run by Rafael every few months), this worker takes out the trash over the weekend and helps clean up old issues and pull requests in every enabled repo.

![](http://screenshots.chrisarcand.com/4zbep.jpg)

### Details

* A pull request or issue that hasn't been updated (commented on, whatever) in the last **6 months** is considered stale.
* Stale *issues* are marked with the 'stale' label and commented on.
* Stale *pull requests* are closed and commented on. 
* As with rails-bot, issues/pull requests can be 'pinned' - that is, if the label 'pinned' (or any other label that we deem worthy) is present on the issue, it will not be marked as stale or closed even if it's extremely old. This is useful for longstanding things that we know are a continuing issue but take a really long time to fix. 
* The StaleIssueMarker is run every Saturday, specifically, as it potentially uses a fair number of queries and not many people are working on a Saturday. Freshens up the repos for a lovely Monday morning 🌅 ☕️ 
* This worker is a little different in that I've split the concept of 'the worker that does the thing' and 'the worker that schedules the action to be taken with multiple workers'. That is, there's a `StaleIssueMarker` and a `Schedulers::StaleIssueMarker`. We should probably follow a pattern more like this with other things we do to do more things asynchronously. Thoughts?

*Why are you labeling issues but closing PRs?*  
* As assumed with rails-bot, issues should probably be at least glanced at before actually closed. If an issue is marked as 'stale', the finder of the issue should assume that unless they reproduce the issue soon, a committer can come along and just close it without having to spend the time to explain themselves too much. 
* Pull requests, on the other hand, have a true shelf life. If a PR isn't touched for months, there's a *very high* probability that it isn't even mergable and the contributor will probably just close it anyway - and even if it were to be eventually worked on again, it will probably be changed enough that the contributor should just make a brand new pull request anyway.

### Deployment

This includes tests, but even still, changing the state of hundreds of issues/PRs on the core repo is scary stuff 👻  Therefore, I'll run this on the miq_bot repo first to make sure it doesn't cause a chaos monkey 🐒 