### PR TITLE
Pull old milestones, too

### DIFF
--- a/lib/github_service.rb
+++ b/lib/github_service.rb
@@ -81,7 +81,7 @@ module GithubService
     end
 
     def milestones(fq_name)
-      milestones_cache[fq_name] ||= Hash[service.list_milestones(fq_name).map { |m| [m.title, m.number] }]
+      milestones_cache[fq_name] ||= Hash[service.list_milestones(fq_name, :state => :all).map { |m| [m.title, m.number] }]
     end
 
     def valid_milestone?(fq_name, milestone)


### PR DESCRIPTION
People sometimes need to retroactively add a milestone to a PR that was
merged in the previous sprint. Without this option, you can only assign
to the current open sprint.

See https://github.com/ManageIQ/manageiq-gems-pending/pull/77