### PR TITLE
Fix irreverible migration

### DIFF
--- a/db/migrate/20170127173128_fix_limit_in_schema.rb
+++ b/db/migrate/20170127173128_fix_limit_in_schema.rb
@@ -1,5 +1,5 @@
 class FixLimitInSchema < ActiveRecord::Migration
-  def change
+  def up
     change_column :batch_entries, :state, :string, :limit => 255
     change_column :batch_jobs, :on_complete_class, :string, :limit => 255
     change_column :batch_jobs, :state, :string, :limit => 255
@@ -7,5 +7,15 @@ class FixLimitInSchema < ActiveRecord::Migration
     change_column :branches, :commit_uri, :string, :limit => 255
     change_column :branches, :last_commit, :string, :limit => 255
     change_column :repos, :name, :string, :limit => 255
+  end
+
+  def down
+    change_column :batch_entries, :state, :string, :limit => nil
+    change_column :batch_jobs, :on_complete_class, :string, :limit => nil
+    change_column :batch_jobs, :state, :string, :limit => nil
+    change_column :branches, :name, :string, :limit => nil
+    change_column :branches, :commit_uri, :string, :limit => nil
+    change_column :branches, :last_commit, :string, :limit => nil
+    change_column :repos, :name, :string, :limit => nil
   end
 end


### PR DESCRIPTION
Trying to revert this migration results in this error:

```
== 20170127173128 FixLimitInSchema: reverting =================================
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

ActiveRecord::IrreversibleMigration/home/tim/src/miq_bot/vendor/bundle/ruby/2.3.0/gems/activerecord-4.2.7/lib/active_record/migration/comman
d_recorder.rb:65:in `inverse_of'
```

~~Changing it to an `up` and doing nothing on the `down` should be fine.~~

Edit: We need to tell it explicitly how to undo the change by setting
`:limit => nil`.

@miq-bot assign @chrisarcand 