### PR TITLE
Add a YAML linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 cache: bundler
 services:
 - redis-server
+before_install:
+- sudo pip install yamllint
 before_script:
 - cp config/database.tmpl.yml config/database.yml
 - bundle exec rake db:setup

--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -24,6 +24,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
     unmerged_results = []
     unmerged_results << Linter::Rubocop.new(branch).run
     unmerged_results << Linter::Haml.new(branch).run
+    unmerged_results << Linter::Yaml.new(branch).run
     unmerged_results.compact!
     if unmerged_results.empty?
       @results = {"files" => []}

--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder.rb
@@ -42,7 +42,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
   end
 
   def header
-    header1 = "Checked #{"commit".pluralize(commits.length)} #{commit_range_text} with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}"
+    header1 = "Checked #{"commit".pluralize(commits.length)} #{commit_range_text} with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, haml-lint #{hamllint_version}, and yamllint #{yamllint_version}"
 
     file_count    = results.fetch_path("summary", "target_file_count").to_i
     offense_count = results.fetch_path("summary", "offense_count").to_i
@@ -123,5 +123,10 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder
 
   def hamllint_version
     HamlLint::VERSION
+  end
+
+  def yamllint_version
+    _out, err, _ps = Open3.capture3("yamllint -v")
+    err.split.last
   end
 end

--- a/lib/linter/base.rb
+++ b/lib/linter/base.rb
@@ -27,18 +27,20 @@ module Linter
         end
       end
 
-      begin
-        offenses = JSON.parse(result.output.chomp)
-      rescue JSON::ParserError => error
-        logger.error("#{log_header} #{error.message}")
-        logger.error("#{log_header} Failed to parse JSON result #{result.output.inspect}")
-        return failed_linter_offenses("error parsing JSON result")
-      end
+      offenses = parse_output(result.output)
       logger.info("#{log_header} Completed run with offenses #{offenses.inspect}")
       offenses
     end
 
     private
+
+    def parse_output(output)
+      JSON.parse(output.chomp)
+    rescue JSON::ParserError => error
+      logger.error("#{log_header} #{error.message}")
+      logger.error("#{log_header} Failed to parse JSON result #{output.inspect}")
+      return failed_linter_offenses("error parsing JSON result")
+    end
 
     def collected_config_files(dir)
       config_files.select { |path| extract_file(path, dir) }

--- a/lib/linter/yaml.rb
+++ b/lib/linter/yaml.rb
@@ -1,0 +1,53 @@
+module Linter
+  class Yaml < Base
+    private
+
+    REGEX = /(?<filename>.*):(?<line>\d+):(?<column>\d+): \[(?<severity>.*)\] (?<message>.*) \((?<cop_name>.*)\)/
+
+    def parse_output(output)
+      lines = output.chomp.split("\n")
+      parsed = lines.collect { |line| REGEX.match(line) }
+      grouped = parsed.group_by { |match| match[:filename] }
+      file_count = parsed.collect { |match| match[:filename] }.uniq.count
+      {
+        "files"   => grouped.collect do |filename, offenses|
+          {
+            "path"     => filename.sub(%r{\A\./}, ""),
+            "offenses" => offenses.collect do |match|
+              {
+                "severity" => match[:severity],
+                "message"  => match[:message],
+                "cop_name" => match[:cop_name],
+                "location" => {
+                  "line"   => match[:line].to_i,
+                  "column" => match[:column].to_i
+                }
+              }
+            end
+          }
+        end,
+        "summary" => {
+          "offense_count"        => lines.size,
+          "target_file_count"    => file_count,
+          "inspected_file_count" => file_count
+        }
+      }
+    end
+
+    def linter_executable
+      "yamllint"
+    end
+
+    def config_files
+      [".yamllint"]
+    end
+
+    def options
+      {:f => "parsable", nil => ["."]}
+    end
+
+    def filtered_files(files)
+      files.select { |f| f.end_with?(".yml", ".yaml") }
+    end
+  end
+end

--- a/spec/lib/linter/yaml_spec.rb
+++ b/spec/lib/linter/yaml_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe Linter::Yaml do
+  describe "#parse_output" do
+    it "does something" do
+      output = <<-EOOUTPUT
+config/settings.yml:8:5: [warning] wrong indentation: expected 2 but found 4 (indentation)
+config/settings.yml:11:1: [error] duplication of key ":a" in mapping (key-duplicates)
+EOOUTPUT
+
+      actual = described_class.new(double("branch")).send(:parse_output, output)
+
+      expected = {
+        "files"   => [
+          {
+            "path"     => "config/settings.yml",
+            "offenses" => a_collection_containing_exactly(
+              {
+                "severity" => "warning",
+                "message"  => "wrong indentation: expected 2 but found 4",
+                "cop_name" => "indentation",
+                "location" => {
+                  "line"   => 8,
+                  "column" => 5
+                }
+              },
+              {
+                "severity" => "error",
+                "message"  => "duplication of key \":a\" in mapping",
+                "cop_name" => "key-duplicates",
+                "location" => {
+                  "line"   => 11,
+                  "column" => 1
+                }
+              }
+            )
+          }
+        ],
+        "summary" => {
+          "offense_count"        => 2,
+          "target_file_count"    => 1,
+          "inspected_file_count" => 1
+        },
+      }
+      expect(actual).to include(expected)
+    end
+  end
+end

--- a/spec/support/rubocop_spec_helper.rb
+++ b/spec/support/rubocop_spec_helper.rb
@@ -36,3 +36,8 @@ end
 def hamllint_version
   HamlLint::VERSION
 end
+
+def yamllint_version
+  _out, err, _ps = Open3.capture3("yamllint -v")
+  err.split.last
+end

--- a/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/message_builder_spec.rb
@@ -20,7 +20,7 @@ describe CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder do
     it "with results with offenses" do
       expect(subject.length).to eq 1
       expect(subject.first).to  eq <<-EOMSG
-<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, haml-lint #{hamllint_version}, and yamllint #{yamllint_version}
 4 files checked, 4 offenses detected
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/coding_convention.rb**
@@ -39,7 +39,7 @@ describe CommitMonitorHandlers::CommitRange::RubocopChecker::MessageBuilder do
     it "with results with no offenses" do
       expect(subject.length).to eq 1
       expect(subject.first).to  start_with <<-EOMSG.chomp
-<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, haml-lint #{hamllint_version}, and yamllint #{yamllint_version}
 1 file checked, 0 offenses detected
 Everything looks fine.
       EOMSG
@@ -49,7 +49,7 @@ Everything looks fine.
     it "with results generating multiple comments" do
       expect(subject.length).to eq 2
       expect(subject.first).to  start_with <<-EOMSG.chomp
-<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, haml-lint #{hamllint_version}, and yamllint #{yamllint_version}
 1 file checked, 293 offenses detected
       EOMSG
       expect(subject.last).to   start_with "<rubocop />**...continued**\n"
@@ -58,7 +58,7 @@ Everything looks fine.
     it "with results without column numbers and cop names" do
       expect(subject.length).to eq 1
       expect(subject.first).to  eq <<-EOMSG
-<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, and haml-lint #{hamllint_version}
+<rubocop />Checked commits https://github.com/some_user/some_repo/compare/1ec36efd33279f79f8ddcf12984bb2aa48f3fbd6~...8942a195a0bfa69ceb82c020c60565408cb46d3e with ruby #{RUBY_VERSION}, rubocop #{rubocop_version}, haml-lint #{hamllint_version}, and yamllint #{yamllint_version}
 1 file checked, 1 offense detected
 
 **spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/#{rubocop_check_directory}/example.haml**


### PR DESCRIPTION
Warning: requires a `yamllint` executable on the path of the bot. It's available in dnf/apt/etc... but I'd recommend using the most recent version available via `pip`.

See https://github.com/miq-test/sandbox/pull/42#issuecomment-332899807 for an example of output.

@miq-bot assign @Fryguy 