### PR TITLE
Change stale issue marker to Mondays

### DIFF
--- a/app/workers/schedulers/stale_issue_marker.rb
+++ b/app/workers/schedulers/stale_issue_marker.rb
@@ -4,7 +4,7 @@ module Schedulers
     sidekiq_options :queue => :miq_bot_glacial, :retry => false
 
     include Sidetiq::Schedulable
-    recurrence { weekly.day(:saturday) }
+    recurrence { weekly.day(:monday) }
 
     include SidekiqWorkerMixin
 


### PR DESCRIPTION
I've realized that having a ton of notifications at the beginning of a relaxing weekend is actually sort of stressful even if it's just the bot marking stuff. Part of that is being disciplined enough to ignore your notifications for the weekend, but there's no reason we can't alleviate the perceived pain.

This will activate at midnight (ET) on Sunday night, really, so people will be notified of stale stuff they might want to go over that week on Monday morning.