### PR TITLE
Implement a daily Code analyzer

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -13,6 +13,8 @@ class Branch < ActiveRecord::Base
 
   delegate :enabled_for?, :to => :repo
 
+  scope :regular_branches, -> { where(:pull_request => [false, nil]) }
+
   def self.with_branch_or_pr_number(n)
     n = MinigitService.pr_branch(n) if n.kind_of?(Fixnum)
     where(:name => n)

--- a/app/workers/commit_monitor_handlers/branch/code_analyzer.rb
+++ b/app/workers/commit_monitor_handlers/branch/code_analyzer.rb
@@ -21,17 +21,8 @@ class CommitMonitorHandlers::Branch::CodeAnalyzer
 
   def analyze
     branch.repo.git_fetch
-    run_linters
+    @results = merge_linter_results(run_all_linters)
     offense_count = @results.fetch_path("summary", "offense_count")
     branch.update_attributes(:linter_offense_count => offense_count)
-  end
-
-  def run_linters
-    unmerged_results = run_all_linters
-    if unmerged_results.empty?
-      @results = {"files" => []}
-    else
-      @results = merge_linter_results(*unmerged_results)
-    end
   end
 end

--- a/app/workers/commit_monitor_handlers/branch/code_analyzer.rb
+++ b/app/workers/commit_monitor_handlers/branch/code_analyzer.rb
@@ -1,0 +1,37 @@
+require 'rugged'
+
+class CommitMonitorHandlers::Branch::CodeAnalyzer
+  include Sidekiq::Worker
+  sidekiq_options :queue => :miq_bot_glacial
+
+  include BranchWorkerMixin
+  include ::CodeAnalysisMixin
+
+  def self.handled_branch_modes
+    [:regular]
+  end
+
+  def perform(branch_id)
+    return unless find_branch(branch_id, :regular)
+
+    analyze
+  end
+
+  private
+
+  def analyze
+    branch.repo.git_fetch
+    run_linters
+    offense_count = @results.fetch_path("summary", "offense_count")
+    branch.update_attributes(:linter_offense_count => offense_count)
+  end
+
+  def run_linters
+    unmerged_results = run_all_linters
+    if unmerged_results.empty?
+      @results = {"files" => []}
+    else
+      @results = merge_linter_results(*unmerged_results)
+    end
+  end
+end

--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -22,11 +22,8 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
   private
 
   def process_branch
-    unmerged_results = run_all_linters
-    if unmerged_results.empty?
-      @results = {"files" => []}
-    else
-      results      = merge_linter_results(*unmerged_results)
+    @results = merge_linter_results(run_all_linters)
+    unless @results["files"].empty?
       diff_details = diff_details_for_merge
       @results     = RubocopResultsFilter.new(results, diff_details).filtered
     end

--- a/app/workers/concerns/code_analysis_mixin.rb
+++ b/app/workers/concerns/code_analysis_mixin.rb
@@ -11,6 +11,9 @@ module CodeAnalysisMixin
       new_results['files'] += result['files']
     end
 
+    new_results ||= {}
+    new_results["files"] ||= []
+
     new_results
   end
 

--- a/app/workers/concerns/code_analysis_mixin.rb
+++ b/app/workers/concerns/code_analysis_mixin.rb
@@ -1,0 +1,24 @@
+module CodeAnalysisMixin
+  def merge_linter_results(*results)
+    return if results.empty?
+
+    new_results = results[0].dup
+
+    results[1..-1].each do |result|
+      %w(offense_count target_file_count inspected_file_count).each do |m|
+        new_results['summary'][m] += result['summary'][m]
+      end
+      new_results['files'] += result['files']
+    end
+
+    new_results
+  end
+
+  def run_all_linters
+    unmerged_results = []
+    unmerged_results << Linter::Rubocop.new(branch).run
+    unmerged_results << Linter::Haml.new(branch).run
+    unmerged_results << Linter::Yaml.new(branch).run
+    unmerged_results.compact!
+  end
+end

--- a/app/workers/schedulers/code_analyzer.rb
+++ b/app/workers/schedulers/code_analyzer.rb
@@ -10,7 +10,7 @@ module Schedulers
 
     def perform
       Repo.where(:name => fq_repo_names).each do |repo|
-        repo.branches.pluck(:id).each do |branch_id|
+        repo.branches.regular_branches.pluck(:id).each do |branch_id|
           CommitMonitorHandlers::Branch::CodeAnalyzer.perform_async(branch_id)
         end
       end

--- a/app/workers/schedulers/code_analyzer.rb
+++ b/app/workers/schedulers/code_analyzer.rb
@@ -1,0 +1,25 @@
+module Schedulers
+  class CodeAnalyzer
+    include Sidekiq::Worker
+    sidekiq_options :queue => :miq_bot_glacial, :retry => false
+
+    include Sidetiq::Schedulable
+    recurrence { daily }
+
+    include SidekiqWorkerMixin
+
+    def perform
+      Repo.where(:name => fq_repo_names).each do |repo|
+        repo.branches.pluck(:id).each do |branch_id|
+          CommitMonitorHandlers::Branch::CodeAnalyzer.perform_async(branch_id)
+        end
+      end
+    end
+
+    private
+
+    def fq_repo_names
+      Settings.code_analyzer.enabled_repos
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,6 +20,8 @@ grafana:
   url:
 
 # Worker settings
+code_analyzer:
+  enabled_repos: []
 diff_content_checker: {}
 github_notification_monitor:
   repo_names: []

--- a/db/migrate/20171006050814_add_linter_offense_count_to_branch.rb
+++ b/db/migrate/20171006050814_add_linter_offense_count_to_branch.rb
@@ -1,0 +1,5 @@
+class AddLinterOffenseCountToBranch < ActiveRecord::Migration
+  def change
+    add_column :branches, :linter_offense_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170127173128) do
+ActiveRecord::Schema.define(version: 20171006050814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,9 +34,9 @@ ActiveRecord::Schema.define(version: 20170127173128) do
   end
 
   create_table "branches", force: :cascade do |t|
-    t.string   "name",            limit: 255
-    t.string   "commit_uri",      limit: 255
-    t.string   "last_commit",     limit: 255
+    t.string   "name",                 limit: 255
+    t.string   "commit_uri",           limit: 255
+    t.string   "last_commit",          limit: 255
     t.integer  "repo_id"
     t.boolean  "pull_request"
     t.datetime "last_checked_on"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 20170127173128) do
     t.boolean  "mergeable"
     t.string   "merge_target"
     t.string   "pr_title"
+    t.integer  "linter_offense_count"
   end
 
   create_table "repos", force: :cascade do |t|

--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -54,22 +54,21 @@ module GitService
     end
 
     def tip_files
-      recursive_list_files_in_tree(tip_tree.oid)
+      list_files_in_tree(tip_tree.oid)
     end
 
     private
 
-    def recursive_list_files_in_tree(rugged_tree_oid, files = [], current_path = Pathname.new(""))
-      rugged_repo.lookup(rugged_tree_oid).each do |i|
+    def list_files_in_tree(rugged_tree_oid, current_path = Pathname.new(""))
+      rugged_repo.lookup(rugged_tree_oid).each_with_object([]) do |i, files|
         full_path = current_path.join(i[:name])
         case i[:type]
         when :blob
           files << full_path.to_s
         when :tree
-          recursive_list_files_in_tree(i[:oid], files, full_path)
+          files.concat(list_files_in_tree(i[:oid], full_path))
         end
       end
-      files
     end
 
     def ref_name

--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -61,11 +61,12 @@ module GitService
 
     def recursive_list_files_in_tree(rugged_tree_oid, files = [], current_path = Pathname.new(""))
       rugged_repo.lookup(rugged_tree_oid).each do |i|
+        full_path = current_path.join(i[:name])
         case i[:type]
         when :blob
-          files << current_path.join(i[:name]).to_s
+          files << full_path.to_s
         when :tree
-          recursive_list_files_in_tree(i[:oid], files, current_path.join(i[:name]))
+          recursive_list_files_in_tree(i[:oid], files, full_path)
         end
       end
       files

--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -53,7 +53,23 @@ module GitService
       rugged_repo.references[reference].target
     end
 
+    def tip_files
+      recursive_list_files_in_tree(tip_tree.oid)
+    end
+
     private
+
+    def recursive_list_files_in_tree(rugged_tree_oid, files = [], current_path = Pathname.new(""))
+      rugged_repo.lookup(rugged_tree_oid).each do |i|
+        case i[:type]
+        when :blob
+          files << current_path.join(i[:name]).to_s
+        when :tree
+          recursive_list_files_in_tree(i[:oid], files, current_path.join(i[:name]))
+        end
+      end
+      files
+    end
 
     def ref_name
       return "refs/#{branch.name}" if branch.name.include?("prs/")

--- a/lib/linter/base.rb
+++ b/lib/linter/base.rb
@@ -69,7 +69,7 @@ module Linter
     end
 
     def files_to_lint
-      @files_to_lint ||= filtered_files(diff_service.new_files)
+      @files_to_lint ||= branch.pull_request? ? filtered_files(diff_service.new_files) : branch.git_service.tip_files
     end
 
     def run_linter(dir)


### PR DESCRIPTION
I hope this will be added to the statistics on the Sprint review. Here we can have an overall metric on how many linter offenses there are in each repo.  Eventually I'd like to keep historical data, but on this first pass, we can get daily numbers saved on the branch record.