### PR TITLE
New comment issues

### DIFF
--- a/lib/github_notification_monitor.rb
+++ b/lib/github_notification_monitor.rb
@@ -31,8 +31,10 @@ class GithubNotificationMonitor
   # last_processed_timestamp, and check every comment in the issue thread
   # skipping them until we are at the last processed comment.
   def process_notification(notification)
-    issue = GithubService.issue(@fq_repo_name, notification.issue_number)
-    process_issue_thread(issue)
+    if notification.issue_number.present?
+      issue = GithubService.issue(@fq_repo_name, notification.issue_number)
+      process_issue_thread(issue)
+    end
     notification.mark_thread_as_read
   end
 

--- a/lib/github_notification_monitor.rb
+++ b/lib/github_notification_monitor.rb
@@ -46,6 +46,11 @@ class GithubNotificationMonitor
   end
 
   def process_issue_comment(issue, author, timestamp, body)
+    if body.blank?
+      logger.warn("Skipping comment due to empty body. Issue: #{issue.url} Author: #{author}, Timestamp: #{timestamp}")
+      return
+    end
+
     last_processed_timestamp = timestamps[issue.number] || Time.at(0)
     return if timestamp <= last_processed_timestamp
 

--- a/lib/github_service/notification.rb
+++ b/lib/github_service/notification.rb
@@ -7,7 +7,7 @@ module GithubService
     end
 
     def issue_number
-      subject.url.match(/[0-9]+\Z/).to_s
+      subject.url.match(/\/([0-9]+)\Z/).try(:[], 1)
     end
 
     private


### PR DESCRIPTION
- Don't blow up when a comment body is nil
  - Example: https://github.com/ManageIQ/manageiq-appliance/pull/147
- Enhance `issue_number` matching to verify that everything after `/` is an integer
- Only process notifications that have an `issue_number`