### PR TITLE
Prevent errors from empty linter results

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb
@@ -23,7 +23,7 @@ class CommitMonitorHandlers::CommitRange::RubocopChecker
 
   def process_branch
     @results = merged_linter_results
-    unless @results["files"].empty?
+    unless @results["files"].blank?
       diff_details = diff_details_for_merge
       @results     = RubocopResultsFilter.new(results, diff_details).filtered
     end

--- a/app/workers/concerns/code_analysis_mixin.rb
+++ b/app/workers/concerns/code_analysis_mixin.rb
@@ -1,7 +1,7 @@
 module CodeAnalysisMixin
   def merged_linter_results
     results = run_all_linters
-    return if results.empty?
+    return {} if results.empty?
 
     new_results = results[0].dup
 


### PR DESCRIPTION
(No linters enabled for a branch)