### PR TITLE
Change PrMergeabilityChecker queue as it's no longer a glacial operation

### DIFF
--- a/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
+++ b/app/workers/commit_monitor_handlers/branch/pr_mergeability_checker.rb
@@ -1,6 +1,6 @@
 class CommitMonitorHandlers::Branch::PrMergeabilityChecker
   include Sidekiq::Worker
-  sidekiq_options :queue => :miq_bot_glacial
+  sidekiq_options :queue => :miq_bot
 
   include BranchWorkerMixin
 


### PR DESCRIPTION
Since it now uses rugged to check mergeability and does not hold a lock on git, it is a fast operation and can be moved to the faster queue.