### PR TITLE
Fix issue where BZ URLs prefixed with a resolution were not detected

### DIFF
--- a/lib/bugzilla_service.rb
+++ b/lib/bugzilla_service.rb
@@ -41,7 +41,7 @@ class BugzillaService
     regex = match_regex
 
     message.each_line.collect do |line|
-      match = regex.match(line)
+      match = regex.match(line.strip)
       match && Hash[match.names.zip(match.captures)].tap do |h|
         h.symbolize_keys!
         h[:bug_id]     &&= h[:bug_id].to_i

--- a/spec/lib/bugzilla_service_spec.rb
+++ b/spec/lib/bugzilla_service_spec.rb
@@ -12,6 +12,21 @@ describe BugzillaService do
     described_class.call { |bz| yield bz }
   end
 
+  def commit_message(body)
+    <<-EOF
+commit 0123456789abcdef0123456789abcdef01234567
+Author:     Some Author <some.author@example.com>
+AuthorDate: Mon Nov 13 13:57:41 2017 -0500
+Commit:     Some Committer <some.committer@example.com>
+CommitDate: Mon Nov 13 14:16:33 2017 -0500
+
+    #{body.chomp.gsub("\n", "\n    ")}
+
+ lib/miq_bot.rb | 5 +++++
+ 1 file changed, 5 insertions(+)
+    EOF
+  end
+
   it_should_behave_like "ThreadsafeServiceMixin service"
 
   describe ".search_in_message" do
@@ -20,7 +35,7 @@ describe BugzillaService do
     end
 
     it "with no bugs" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
       EOF
 
@@ -28,7 +43,7 @@ This is a commit message
     end
 
     it "with one bug (with regular format)" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/123456
@@ -40,7 +55,7 @@ https://bugzilla.redhat.com/123456
     end
 
     it "with one bug (with cgi format)" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -52,7 +67,7 @@ https://bugzilla.redhat.com/show_bug.cgi?id=123456
     end
 
     it "with multiple bugs" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -68,7 +83,7 @@ https://bugzilla.redhat.com/345678
     it "when the URL in settings has a trailing slash" do
       stub_settings(:bugzilla_credentials => {:url => "https://bugzilla.redhat.com/"})
 
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -84,7 +99,7 @@ https://bugzilla.redhat.com/345678
     it "when the URL in settings not set" do
       stub_nil_settings(:bugzilla_credentials => {:url => nil})
 
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -95,7 +110,7 @@ https://bugzilla.redhat.com/345678
     end
 
     it "with oddly formed URL" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com//show_bug.cgi?id=123456
@@ -109,7 +124,7 @@ https://bugzilla.redhat.com//show_bug.cgi?id=123456
     described_class::CLOSING_KEYWORDS.each do |base_word|
       [base_word, base_word.capitalize, "#{base_word}:", "#{base_word.capitalize}:"].each do |keyword|
         it "detects an id when the URL is prefixed with closing keyword '#{keyword}'" do
-          message = <<-EOF
+          message = commit_message(<<-EOF)
 This is a commit message
 
 #{keyword} https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -131,7 +146,7 @@ This is a commit message
     end
 
     it "with no bugs" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
       EOF
 
@@ -139,7 +154,7 @@ This is a commit message
     end
 
     it "with one bug (with regular format)" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/123456
@@ -149,7 +164,7 @@ https://bugzilla.redhat.com/123456
     end
 
     it "with one bug (with cgi format)" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -159,7 +174,7 @@ https://bugzilla.redhat.com/show_bug.cgi?id=123456
     end
 
     it "with multiple bugs" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -172,7 +187,7 @@ https://bugzilla.redhat.com/345678
     it "when the URL in settings has a trailing slash" do
       stub_settings(:bugzilla_credentials => {:url => "https://bugzilla.redhat.com/"})
 
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -185,7 +200,7 @@ https://bugzilla.redhat.com/345678
     it "when the URL in settings not set" do
       stub_nil_settings(:bugzilla_credentials => {:url => nil})
 
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com/show_bug.cgi?id=123456
@@ -196,7 +211,7 @@ https://bugzilla.redhat.com/345678
     end
 
     it "with oddly formed URL" do
-      message = <<-EOF
+      message = commit_message(<<-EOF)
 This is a commit message
 
 https://bugzilla.redhat.com//show_bug.cgi?id=123456
@@ -208,7 +223,7 @@ https://bugzilla.redhat.com//show_bug.cgi?id=123456
     described_class::CLOSING_KEYWORDS.each do |base_word|
       [base_word, base_word.capitalize, "#{base_word}:", "#{base_word.capitalize}:"].each do |keyword|
         it "detects an id when the URL is prefixed with closing keyword '#{keyword}'" do
-          message = <<-EOF
+          message = commit_message(<<-EOF)
 This is a commit message
 
 #{keyword} https://bugzilla.redhat.com/show_bug.cgi?id=123456


### PR DESCRIPTION
The tests did not catch this originally because they were not real-world
examples where git commit messages are used, and thus the message itself
is indented 4 spaces.  Regular URLs happened to work because the regex
has a \s* immediately after the optional resolution string.

@bdunne Please review.