### PR TITLE
Merge rubocop config files for linting purposes

### DIFF
--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -7,8 +7,8 @@ module GitService
       @branch = branch
     end
 
-    def content_at(path)
-      blob_at(path).try(:content)
+    def content_at(path, merged = false)
+      blob_at(path, merged).try(:content)
     end
 
     def diff(merge_target = nil)
@@ -85,8 +85,10 @@ module GitService
       "refs/remotes/origin/#{ref}"
     end
 
-    def blob_at(path) # Rugged::Blob object for a given file path on this branch
-      blob_data = tip_tree.path(path)
+    # Rugged::Blob object for a given file path on this branch
+    def blob_at(path, merged = false)
+      source = merged ? merge_tree : tip_tree
+      blob_data = source.path(path)
       blob = Rugged::Blob.lookup(rugged_repo, blob_data[:oid])
       blob.type == :blob ? blob : nil
     rescue Rugged::TreeError

--- a/lib/linter/base.rb
+++ b/lib/linter/base.rb
@@ -45,15 +45,15 @@ module Linter
     end
 
     def collected_config_files(dir)
-      config_files.select { |path| extract_file(path, dir) }
+      config_files.select { |path| extract_file(path, dir, branch.pull_request?) }
     end
 
     def collected_files_to_lint(dir)
       files_to_lint.select { |path| extract_file(path, dir) }
     end
 
-    def extract_file(path, destination_dir)
-      content = branch_service.content_at(path)
+    def extract_file(path, destination_dir, merged = false)
+      content = branch_service.content_at(path, merged)
       return false unless content
 
       temp_file = File.join(destination_dir, path)


### PR DESCRIPTION
We want the regular files from the tip of the branch, but we want the config files to be merged before running.