### PR TITLE
Reduce callers to git_service

### DIFF
--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -118,7 +118,7 @@ class CommitMonitor
     @new_commits_details ||=
       new_commits.each_with_object({}) do |commit, h|
         h[commit] = {
-          "message" => git.commit_message(commit),
+          "message" => branch.git_service.commit_message(commit),
           "files"   => git.diff_file_names(commit)
         }
       end

--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -55,23 +55,21 @@ class CommitMonitor
 
   private
 
-  attr_reader :repo, :git, :branch, :new_commits, :all_commits, :statistics
+  attr_reader :repo, :branch, :new_commits, :all_commits, :statistics
 
   def process_repo(repo)
     @statistics = {}
 
     @repo = repo
-    repo.with_git_service do |git|
-      @git = git
+    repo.git_fetch
 
-      # Sort PR branches after regular branches
-      sorted_branches = repo.branches.sort_by { |b| b.pull_request? ? 1 : -1 }
+    # Sort PR branches after regular branches
+    sorted_branches = repo.branches.sort_by { |b| b.pull_request? ? 1 : -1 }
 
-      sorted_branches.each do |branch|
-        @new_commits_details = nil
-        @branch = branch
-        process_branch
-      end
+    sorted_branches.each do |branch|
+      @new_commits_details = nil
+      @branch = branch
+      process_branch
     end
   end
 

--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -118,7 +118,7 @@ class CommitMonitor
     @new_commits_details ||=
       new_commits.each_with_object({}) do |commit, h|
         h[commit] = {
-          "message" => branch.git_service.commit_message(commit),
+          "message" => branch.git_service.commit(commit).full_message,
           "files"   => git.diff_file_names(commit)
         }
       end

--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -97,7 +97,7 @@ class CommitMonitor
   end
 
   def detect_commits_on_pr_branch
-    all        = git.new_commits(git.merge_base(branch.name, branch.local_merge_target), branch.name)
+    all        = branch.git_service.commit_ids_since(branch.git_service.merge_base)
     comparison = compare_commits_list(branch.commits_list, all)
     return comparison[:right_only], all
   end

--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -77,7 +77,6 @@ class CommitMonitor
 
   def process_branch
     logger.info "Processing #{repo.name}/#{branch.name}"
-    update_branch
 
     @new_commits, @all_commits = detect_commits
 
@@ -89,18 +88,12 @@ class CommitMonitor
     process_handlers
   end
 
-  def update_branch
-    return if branch.pull_request?
-    git.checkout(branch.name)
-    git.pull
-  end
-
   def detect_commits
     send("detect_commits_on_#{branch.mode}_branch")
   end
 
   def detect_commits_on_regular_branch
-    return git.new_commits(branch.last_commit), nil
+    return branch.git_service.commit_ids_since(branch.last_commit), nil
   end
 
   def detect_commits_on_pr_branch

--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -117,9 +117,10 @@ class CommitMonitor
   def new_commits_details
     @new_commits_details ||=
       new_commits.each_with_object({}) do |commit, h|
+        git_commit = branch.git_service.commit(commit)
         h[commit] = {
-          "message" => branch.git_service.commit(commit).full_message,
-          "files"   => git.diff_file_names(commit)
+          "message" => git_commit.full_message,
+          "files"   => git_commit.diff.file_status.keys
         }
       end
   end

--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -61,6 +61,10 @@ module GitService
       list_files_in_tree(tip_tree.oid)
     end
 
+    def commit_ids_since(starting_point)
+      range_walker(starting_point).collect(&:oid).reverse
+    end
+
     private
 
     def list_files_in_tree(rugged_tree_oid, current_path = Pathname.new(""))
@@ -72,6 +76,12 @@ module GitService
         when :tree
           files.concat(list_files_in_tree(i[:oid], full_path))
         end
+      end
+    end
+
+    def range_walker(walk_start, walk_end = ref_name)
+      Rugged::Walker.new(rugged_repo).tap do |walker|
+        walker.push_range("#{walk_start}..#{walk_end}")
       end
     end
 

--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -65,26 +65,8 @@ module GitService
       range_walker(starting_point).collect(&:oid).reverse
     end
 
-    def commit_message(ref)
-      commit = Rugged::Commit.lookup(rugged_repo, ref)
-      parents = commit.parent_oids
-      message = "commit #{commit.oid}\n"
-      message << "Merge: #{parents.join(" ")}\n" if parents.length > 1
-      message << "Author:     #{commit.author[:name]} <#{commit.author[:email]}>\n"
-      message << "AuthorDate: #{commit.author[:time].to_time.strftime("%c %z")}>\n"
-      message << "Commit:     #{commit.author[:name]} <#{commit.author[:email]}>\n"
-      message << "CommitDate: #{commit.author[:time].to_time.strftime("%c %z")}>\n"
-      message << "\n"
-      commit.message.each_line { |line| message << "    #{line}"}
-      message << "\n"
-      previous_commit = Rugged::Commit.lookup(rugged_repo, commit.parent_oids.first)
-      diff = previous_commit.diff(commit)
-      our_diff = Diff.new(diff)
-      our_diff.file_status.each do |file, stats|
-        message << " #{file} | #{stats[:changes]} #{"+" * stats[:additions]}#{"-" * stats[:deletions]}\n"
-      end
-      message << " #{our_diff.status_summary}"
-      message
+    def commit(commit_oid)
+      Commit.new(rugged_repo, commit_oid)
     end
 
     private

--- a/lib/git_service/branch.rb
+++ b/lib/git_service/branch.rb
@@ -65,6 +65,28 @@ module GitService
       range_walker(starting_point).collect(&:oid).reverse
     end
 
+    def commit_message(ref)
+      commit = Rugged::Commit.lookup(rugged_repo, ref)
+      parents = commit.parent_oids
+      message = "commit #{commit.oid}\n"
+      message << "Merge: #{parents.join(" ")}\n" if parents.length > 1
+      message << "Author:     #{commit.author[:name]} <#{commit.author[:email]}>\n"
+      message << "AuthorDate: #{commit.author[:time].to_time.strftime("%c %z")}>\n"
+      message << "Commit:     #{commit.author[:name]} <#{commit.author[:email]}>\n"
+      message << "CommitDate: #{commit.author[:time].to_time.strftime("%c %z")}>\n"
+      message << "\n"
+      commit.message.each_line { |line| message << "    #{line}"}
+      message << "\n"
+      previous_commit = Rugged::Commit.lookup(rugged_repo, commit.parent_oids.first)
+      diff = previous_commit.diff(commit)
+      our_diff = Diff.new(diff)
+      our_diff.file_status.each do |file, stats|
+        message << " #{file} | #{stats[:changes]} #{"+" * stats[:additions]}#{"-" * stats[:deletions]}\n"
+      end
+      message << " #{our_diff.status_summary}"
+      message
+    end
+
     private
 
     def list_files_in_tree(rugged_tree_oid, current_path = Pathname.new(""))

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -34,7 +34,7 @@ module GitService
       message << rugged_commit.message.indent(4)
       message << "\n"
       diff.file_status.each do |file, stats|
-        message << " #{file} | #{stats[:additions].to_i + stats[:deletions].to_i} #{"+" * stats[:additions]}#{"-" * stats[:deletions]}\n"
+        message << " #{file} | #{stats[:additions].to_i + stats[:deletions].to_i} #{"+" if stats[:additions].positive?}#{"-" if stats[:deletions].positive?}\n"
       end
       message << " #{diff.status_summary}"
       message

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -31,7 +31,7 @@ module GitService
       message << "Commit:     #{rugged_commit.author[:name]} <#{rugged_commit.author[:email]}>\n"
       message << "CommitDate: #{rugged_commit.author[:time].to_time.strftime("%c %z")}>\n"
       message << "\n"
-      rugged_commit.message.each_line { |line| message << "    #{line}" }
+      message << rugged_commit.message.indent(4)
       message << "\n"
       diff.file_status.each do |file, stats|
         message << " #{file} | #{stats[:additions].to_i + stats[:deletions].to_i} #{"+" * stats[:additions]}#{"-" * stats[:deletions]}\n"

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -34,7 +34,7 @@ module GitService
       rugged_commit.message.each_line { |line| message << "    #{line}" }
       message << "\n"
       diff.file_status.each do |file, stats|
-        message << " #{file} | #{stats[:changes]} #{"+" * stats[:additions]}#{"-" * stats[:deletions]}\n"
+        message << " #{file} | #{stats[:additions].to_i + stats[:deletions].to_i} #{"+" * stats[:additions]}#{"-" * stats[:deletions]}\n"
       end
       message << " #{diff.status_summary}"
       message

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -1,0 +1,43 @@
+module GitService
+  class Commit
+    attr_reader :commit_oid, :rugged_repo
+    def initialize(rugged_repo, commit_oid)
+      @commit_oid  = commit_oid
+      @rugged_repo = rugged_repo
+    end
+
+    def diff(other_ref = parent_oids.first)
+      Diff.new(rugged_diff(other_ref))
+    end
+
+    def parent_oids
+      @parent_oids ||= rugged_commit.parent_oids
+    end
+
+    def rugged_commit
+      @rugged_commit ||= Rugged::Commit.lookup(rugged_repo, commit_oid)
+    end
+
+    def rugged_diff(other_ref = parent_oids.first)
+      other_commit = Rugged::Commit.lookup(rugged_repo, other_ref)
+      other_commit.diff(rugged_commit)
+    end
+
+    def full_message
+      message = "commit #{commit_oid}\n"
+      message << "Merge: #{parent_oids.join(" ")}\n" if parent_oids.length > 1
+      message << "Author:     #{rugged_commit.author[:name]} <#{rugged_commit.author[:email]}>\n"
+      message << "AuthorDate: #{rugged_commit.author[:time].to_time.strftime("%c %z")}>\n"
+      message << "Commit:     #{rugged_commit.author[:name]} <#{rugged_commit.author[:email]}>\n"
+      message << "CommitDate: #{rugged_commit.author[:time].to_time.strftime("%c %z")}>\n"
+      message << "\n"
+      rugged_commit.message.each_line { |line| message << "    #{line}" }
+      message << "\n"
+      diff.file_status.each do |file, stats|
+        message << " #{file} | #{stats[:changes]} #{"+" * stats[:additions]}#{"-" * stats[:deletions]}\n"
+      end
+      message << " #{diff.status_summary}"
+      message
+    end
+  end
+end

--- a/lib/git_service/diff.rb
+++ b/lib/git_service/diff.rb
@@ -29,14 +29,12 @@ module GitService
       raw_diff.patches.each_with_object({}) do |patch, h|
         if new_file = patch.delta.new_file.try(:[], :path)
           additions = h.fetch_path(new_file, :additions) || 0
-          h.store_path(new_file, :additions, (additions += patch.additions))
+          h.store_path(new_file, :additions, (additions + patch.additions))
         end
         if old_file = patch.delta.old_file.try(:[], :path)
-          deletions = h.fetch_path(new_file, :deletions) || 0
-          h.store_path(new_file, :deletions, (deletions += patch.deletions))
+          deletions = h.fetch_path(old_file, :deletions) || 0
+          h.store_path(new_file, :deletions, (deletions + patch.deletions))
         end
-        changes = h.fetch_path(new_file, :changes) || 0
-        h.store_path(new_file, :changes, (changes += patch.changes))
       end
     end
 

--- a/lib/git_service/diff.rb
+++ b/lib/git_service/diff.rb
@@ -24,5 +24,29 @@ module GitService
         hunk.lines.each { |line| yield(line, hunk, parent_patch) }
       end
     end
+
+    def file_status
+      raw_diff.patches.each_with_object({}) do |patch, h|
+        if new_file = patch.delta.new_file.try(:[], :path)
+          additions = h.fetch_path(new_file, :additions) || 0
+          h.store_path(new_file, :additions, (additions += patch.additions))
+        end
+        if old_file = patch.delta.old_file.try(:[], :path)
+          deletions = h.fetch_path(new_file, :deletions) || 0
+          h.store_path(new_file, :deletions, (deletions += patch.deletions))
+        end
+        changes = h.fetch_path(new_file, :changes) || 0
+        h.store_path(new_file, :changes, (changes += patch.changes))
+      end
+    end
+
+    def status_summary
+      changed, added, deleted = raw_diff.stat
+      [
+        changed.positive? ? "#{changed} #{"file".pluralize(changed)} changed" : nil,
+        added.positive? ? "#{added} #{"insertion".pluralize(added)}(+)" : nil,
+        deleted.positive? ? "#{deleted} #{"deletion".pluralize(deleted)}(-)" : nil
+      ].compact.join(", ")
+    end
   end
 end


### PR DESCRIPTION
We no longer need to lock a repo while running the commit monitor.  Once the fetch is done, everything can be pulled from rugged.  This will unlock future performance improvements like processing multiple repos (and even branches) at the same time.

@Fryguy We need to do some testing before deploying, but everything was working for me in rails console.