### PR TITLE
Review request command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'more_core_extensions', '~> 2.0.0',  :require => 'more_core_extensions/all'
 gem 'rubocop',              '~> 0.52.0', :require => false
 gem 'rugged',                            :require => false
 
-gem 'octokit', '~> 4.6.0', :require => false
+gem 'octokit', '~> 4.8.0', :require => false
 gem 'faraday', '~> 0.9.1'
 gem 'faraday-http-cache', '~> 2.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     net-http-pipeline (1.0.1)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    octokit (4.6.2)
+    octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.12.1)
     parser (2.4.0.2)
@@ -374,7 +374,7 @@ DEPENDENCIES
   listen
   minigit (~> 0.0.4)
   more_core_extensions (~> 2.0.0)
-  octokit (~> 4.6.0)
+  octokit (~> 4.8.0)
   pg
   rails (~> 4.2.4)
   rspec

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ underscores replaced with hyphens.
 
   Example: `@miq-bot assign @user`
 
+- **`add_reviewer [@]user`**
+  Request for pull request review the specified user. The leading `@` for the
+  user is optional. The user must be in the Assignees list.
+
+  Example: `@miq-bot add_reviewer @user`
+
 - **`set_milestone milestone_name`**
   Set the specified milestone on the issue. Do not wrap the
   milestone in quotes.

--- a/lib/github_notification_monitor.rb
+++ b/lib/github_notification_monitor.rb
@@ -10,6 +10,7 @@ class GithubNotificationMonitor
     "remove_label"  => :remove_labels,
     "rm_label"      => :remove_labels,
     "assign"        => :assign,
+    "add_reviewer"  => :add_reviewer,
     "set_milestone" => :set_milestone
   ).freeze
 

--- a/lib/github_service/commands/add_reviewer.rb
+++ b/lib/github_service/commands/add_reviewer.rb
@@ -1,15 +1,15 @@
 module GithubService
   module Commands
-    class Assign < Base
+    class AddReviewer < Base
       private
 
       def _execute(issuer:, value:)
         user = value.strip.delete('@')
 
         if valid_assignee?(user)
-          issue.assign(user)
+          issue.review(user)
         else
-          issue.add_comment("@#{issuer} '#{user}' is an invalid assignee, ignoring...")
+          issue.add_comment("@#{issuer} '#{user}' is an invalid reviewer, ignoring...")
         end
       end
     end

--- a/lib/github_service/commands/add_reviewer.rb
+++ b/lib/github_service/commands/add_reviewer.rb
@@ -7,7 +7,7 @@ module GithubService
         user = value.strip.delete('@')
 
         if valid_assignee?(user)
-          issue.review(user)
+          issue.add_reviewer(user)
         else
           issue.add_comment("@#{issuer} '#{user}' is an invalid reviewer, ignoring...")
         end

--- a/lib/github_service/commands/base.rb
+++ b/lib/github_service/commands/base.rb
@@ -54,6 +54,14 @@ module GithubService
         end
       end
 
+      def valid_assignee?(user)
+        # First reload the cache if it's an invalid assignee
+        GithubService.refresh_assignees(issue.fq_repo_name) unless GithubService.valid_assignee?(issue.fq_repo_name, user)
+
+        # Then see if it's *still* invalid
+        GithubService.valid_assignee?(issue.fq_repo_name, user)
+      end
+
       VALID_RESTRICTIONS = [:organization].freeze
 
       module CommandMethods

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -10,7 +10,7 @@ module GithubService
       GithubService.update_issue(fq_repo_name, number, "assignee" => user)
     end
 
-    def review(user)
+    def add_reviewer(user)
       GithubService.request_pull_request_review(fq_repo_name, number, [user]) if pull_request?
     end
 

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -10,6 +10,10 @@ module GithubService
       GithubService.update_issue(fq_repo_name, number, "assignee" => user)
     end
 
+    def review(user)
+      GithubService.request_pull_request_review(fq_repo_name, number, [user]) if pull_request?
+    end
+
     def set_milestone(milestone)
       if GithubService.valid_milestone?(fq_repo_name, milestone)
         milestone_id = GithubService.milestones(fq_repo_name)[milestone]

--- a/spec/lib/github_service/commands/add_reviewer_spec.rb
+++ b/spec/lib/github_service/commands/add_reviewer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GithubService::Commands::AddReviewer do
     let(:command_value) { "good_user" }
 
     it "review request that user" do
-      expect(issue).to receive(:review).with("good_user")
+      expect(issue).to receive(:add_reviewer).with("good_user")
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.describe GithubService::Commands::AddReviewer do
     let(:command_value) { "bad_user" }
 
     it "does not review request, reports failure" do
-      expect(issue).not_to receive(:assign)
+      expect(issue).not_to receive(:add_reviewer)
       expect(issue).to receive(:add_comment).with("@#{command_issuer} 'bad_user' is an invalid reviewer, ignoring...")
     end
   end

--- a/spec/lib/github_service/commands/review_spec.rb
+++ b/spec/lib/github_service/commands/review_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe GithubService::Commands::AddReviewer do
+  subject { described_class.new(issue) }
+  let(:issue) { double(:fq_repo_name => "org/repo") }
+  let(:command_issuer) { "nickname" }
+
+  before do
+    allow(GithubService).to receive(:valid_assignee?).with("org/repo", "good_user") { true }
+    allow(GithubService).to receive(:valid_assignee?).with("org/repo", "bad_user") { false }
+  end
+
+  after do
+    subject.execute!(:issuer => command_issuer, :value => command_value)
+  end
+
+  context "with a valid user" do
+    let(:command_value) { "good_user" }
+
+    it "review request that user" do
+      expect(issue).to receive(:review).with("good_user")
+    end
+  end
+
+  context "with an invalid user" do
+    let(:command_value) { "bad_user" }
+
+    it "does not review request, reports failure" do
+      expect(issue).not_to receive(:assign)
+      expect(issue).to receive(:add_comment).with("@#{command_issuer} 'bad_user' is an invalid reviewer, ignoring...")
+    end
+  end
+end


### PR DESCRIPTION
## Request for pull request review

### Related issue: https://github.com/ManageIQ/miq_bot/issues/337

ManageIQ Bot will support a new command which provides a "request for pull request review" functionality. This feature required to update Octokit due to [`request_pull_request_review`](https://octokit.github.io/octokit.rb/Octokit/Client/Reviews.html#request_pull_request_review-instance_method) method missing. This command works on the same basis as the [`assign`](https://github.com/ManageIQ/miq_bot) command but it is supported only for pull requests.

Example: `@miq-bot review @europ`

**NOTE**: Command with multiple reviewers are not supported (assign does not support this feature too).

\cc @skateman 
\cc @romanblanco