### PR TITLE
Remove a request for pull request review command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ underscores replaced with hyphens.
 
   Example: `@miq-bot add_reviewer @user`
 
+- **`remove_reviewer [@]user`**
+  Remove a request for pull request review from the specified user. The leading `@` for the
+  user is optional. The user must be in the Assignees list.
+
+  Example: `@miq-bot remove_reviewer @user`
+
 - **`set_milestone milestone_name`**
   Set the specified milestone on the issue. Do not wrap the
   milestone in quotes.

--- a/lib/github_notification_monitor.rb
+++ b/lib/github_notification_monitor.rb
@@ -6,12 +6,13 @@ class GithubNotificationMonitor
     normalized.chop! if normalized.end_with?("s") # Support singular or plural
     h[normalized]    if h.key?(normalized)
   end.merge(
-    "add_label"     => :add_labels,
-    "remove_label"  => :remove_labels,
-    "rm_label"      => :remove_labels,
-    "assign"        => :assign,
-    "add_reviewer"  => :add_reviewer,
-    "set_milestone" => :set_milestone
+    "add_label"       => :add_labels,
+    "remove_label"    => :remove_labels,
+    "rm_label"        => :remove_labels,
+    "assign"          => :assign,
+    "add_reviewer"    => :add_reviewer,
+    "remove_reviewer" => :remove_reviewer,
+    "set_milestone"   => :set_milestone
   ).freeze
 
   def initialize(fq_repo_name)

--- a/lib/github_service/commands/remove_reviewer.rb
+++ b/lib/github_service/commands/remove_reviewer.rb
@@ -1,0 +1,26 @@
+module GithubService
+  module Commands
+    class RemoveReviewer < Base
+      private
+
+      def _execute(issuer:, value:)
+        user = value.strip.delete('@')
+
+        if valid_assignee?(user)
+          if requested_reviewers.include?(user)
+            issue.remove_reviewer(user)
+          else
+            issue.add_comment("@#{issuer} '#{user}' is not in the list of requested reviewers, ignoring...")
+          end
+        else
+          issue.add_comment("@#{issuer} '#{user}' is an invalid reviewer, ignoring...")
+        end
+      end
+
+      # returns an array of user logins who were requested for a pull request review
+      def requested_reviewers
+        GithubService.pull_request_review_requests(fq_repo_name, number).users.map(&:login)
+      end
+    end
+  end
+end

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -14,6 +14,10 @@ module GithubService
       GithubService.request_pull_request_review(fq_repo_name, number, [user]) if pull_request?
     end
 
+    def remove_reviewer(user)
+      GithubService.delete_pull_request_review_request(fq_repo_name, number, "reviewers" => [user]) if pull_request?
+    end
+
     def set_milestone(milestone)
       if GithubService.valid_milestone?(fq_repo_name, milestone)
         milestone_id = GithubService.milestones(fq_repo_name)[milestone]

--- a/spec/lib/github_service/commands/remove_reviewer_spec.rb
+++ b/spec/lib/github_service/commands/remove_reviewer_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe GithubService::Commands::RemoveReviewer do
+  subject { described_class.new(issue) }
+  let(:issue) { double(:fq_repo_name => "org/repo") }
+  let(:command_issuer) { "nickname" }
+
+  before do
+    allow(GithubService).to receive(:valid_assignee?).with("org/repo", "listed_user").and_return(true)
+    allow(GithubService).to receive(:valid_assignee?).with("org/repo", "good_user").and_return(true)
+    allow(GithubService).to receive(:valid_assignee?).with("org/repo", "bad_user").and_return(false)
+
+    allow(subject).to receive(:requested_reviewers).and_return(["listed_user"])
+  end
+
+  after do
+    subject.execute!(:issuer => command_issuer, :value => command_value)
+  end
+
+  context "with a valid user who is actually requested for a review" do
+    let(:command_value) { "listed_user" }
+
+    it "remove review request from that user" do
+      expect(issue).to receive(:remove_reviewer).with("listed_user")
+    end
+  end
+
+  context "with a valid user who is not actually requested for a review" do
+    let(:command_value) { "good_user" }
+
+    it "does not remove review request who is not actually requested" do
+      expect(issue).not_to receive(:remove_reviewer)
+      expect(issue).to receive(:add_comment).with("@#{command_issuer} 'good_user' is not in the list of requested reviewers, ignoring...")
+    end
+  end
+
+  context "with an invalid user" do
+    let(:command_value) { "bad_user" }
+
+    it "does not remove review request, reports failure" do
+      expect(issue).not_to receive(:remove_reviewer)
+      expect(issue).to receive(:add_comment).with("@#{command_issuer} 'bad_user' is an invalid reviewer, ignoring...")
+    end
+  end
+end


### PR DESCRIPTION
## Remove a request for pull request review command

### Related issue: https://github.com/ManageIQ/miq_bot/issues/337

### Dependent on: https://github.com/octokit/octokit.rb/pull/990

<br>

ManageIQ Bot will support a new command `remove_reviewer`. This command provides a "remove request for pull request review" functionality. The usage of this command requires to meet a condition - the user must be a requested reviewer in the pull request. If condition is met, the command perform an action which removes the user from the reviewer list in the pull request.  This command is the opposite of `add_reviewer` which is described in https://github.com/ManageIQ/miq_bot/pull/408

Example: `@miq-bot remove_reviewer @europ`

**NOTE**: Command with multiple reviewers is not supported

\cc @skateman 
\cc @romanblanco