### PR TITLE
Branch status notification via Gitter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'slim'
 # Services gems
 gem 'active_bugzilla'
 gem 'minigit',        '~> 0.0.4'
+gem 'ruby-gitter'
 gem 'tracker_api',    '~> 1.6'
 gem 'travis',         '~> 1.7.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,9 +135,12 @@ GEM
       rubocop (>= 0.47.0)
       sysexits (~> 1.1)
     hashdiff (0.3.6)
+    hashie (3.5.7)
     highline (1.7.8)
     hike (1.2.3)
     hitimes (1.2.6)
+    httparty (0.16.1)
+      multi_xml (>= 0.5.2)
     i18n (0.8.6)
     ice_cube (0.14.0)
     ice_nine (0.11.2)
@@ -171,6 +174,7 @@ GEM
     more_core_extensions (2.0.0)
       activesupport (> 3.2)
     multi_json (1.12.2)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
@@ -258,6 +262,9 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-gitter (0.1.0)
+      hashie
+      httparty
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     rugged (0.26.0)
@@ -380,6 +387,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop (~> 0.52.0)
+  ruby-gitter
   rugged
   sass-rails (~> 4.0.0)
   sidekiq (~> 4.1.1)

--- a/README.md
+++ b/README.md
@@ -215,3 +215,25 @@ worker_d:  # Will raise an exception, since you should not specify both
 worker_e:  # Effectively disables the worker
   included_repos: []
 ```
+
+### Branch notification via Gitter
+
+This feature writes a message notifying Gitter room members on about the status of
+specified branch in a specified repository to a specified Gitter room. The notification
+is set if the branch is broken or fixed. The specifications must be added to configuration
+file.
+
+```yaml
+travis_monitor:
+  gitter_token: "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTt"
+  branches:
+    - repo: "owner/name"
+      branch: "name"
+      gitter_room: "owner/name"
+    - repo: "owner/name"
+      branch: "name"
+      gitter_room: "owner/name"
+    - repo: "owner/name"
+      branch: "name"
+      gitter_room: "owner/name"
+```

--- a/app/workers/gitter_notificator.rb
+++ b/app/workers/gitter_notificator.rb
@@ -1,0 +1,51 @@
+require 'gitter'
+require 'travis'
+
+class GitterNotificator
+  include Sidekiq::Worker
+  sidekiq_options :queue => :miq_bot_glacial, :retry => false
+
+  include Sidetiq::Schedulable
+  recurrence { minutely(10) }
+
+  include SidekiqWorkerMixin
+
+  def perform
+    init
+  end
+
+  private
+
+  def init
+    gitter_token = Settings.travis_monitor.gitter_token
+
+    Settings.travis_monitor.branches.each do |element|
+      build_states = latest_builds(element.repo, element.branch)
+      msg = check(build_states, element.repo, element.branch)
+      gitter_send(element.gitter_room, msg, gitter_token) unless msg.nil?
+    end
+  end
+
+  def check(builds, repository, branch)
+    msg = nil
+
+    if builds[0] == 'passed' && builds[1] == 'failed'
+      msg = ":sos: :warning: \"#{branch}\" in \"#{repository}\" is broken :bangbang: :boom:"
+    elsif builds[0] == 'failed' && builds[1] == 'passed'
+      msg = ":white_check_mark: Broken branch has been fixed :green_heart:"
+    end
+
+    msg
+  end
+
+  def latest_builds(repository, branch)
+    repo = Travis::Repository.find(repository)
+    repo.builds.lazy.select { |b| b.branch_info == branch }.take(2).map(&:state).to_a
+  end
+
+  def gitter_send(room_name, message, gitter_token)
+    client = Gitter::Client.new(gitter_token)
+    room_id = client.rooms.find { |room| room.name == room_name }.id
+    client.send_message(message, room_id)
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,10 @@ influxdb_credentials:
 pivotal_credentials:
   token:
 
+travis_monitor:
+  gitter_token:
+  branches: []
+
 # General settings
 bugzilla:
   product:

--- a/spec/workers/gitter_notificator_spec.rb
+++ b/spec/workers/gitter_notificator_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe GitterNotificator do
+  let(:repository) { "owner/name" }
+  let(:branch) { "master" }
+  let(:room) { "owner/name" }
+
+  describe "#init" do
+    let(:token) { "token" }
+    let(:item_branch) { double("Branch", :repo => "R", :branch => "B", :gitter_room => "GR") }
+    let(:item_travis_monitor) { double("travis_monitor", :gitter_token => token) }
+    let(:build_states) { %w(state1 state2) }
+    let(:msg) { "Hello!" }
+
+    before do
+      allow(Settings).to receive(:travis_monitor).and_return(item_travis_monitor)
+    end
+
+    it "calls #latest_builds, #check and #gitter_send with proper parameters" do
+      allow(item_travis_monitor).to receive(:branches).and_return([item_branch])
+
+      expect(subject).to receive(:latest_builds).with(item_branch.repo, item_branch.branch).and_return(build_states)
+      expect(subject).to receive(:check).with(build_states, item_branch.repo, item_branch.branch).and_return(msg)
+      expect(subject).to receive(:gitter_send).with(item_branch.gitter_room, msg, token)
+
+      subject.send(:init)
+    end
+  end
+
+  describe "#check" do
+    it "sends a broken branch message" do
+      expect(subject.send(:check, %w(passed failed), repository, branch)).to eq(":sos: :warning: \"#{branch}\" in \"#{repository}\" is broken :bangbang: :boom:")
+    end
+
+    it "sends a fixed branch message" do
+      expect(subject.send(:check, %w(failed passed), repository, branch)).to eq(":white_check_mark: Broken branch has been fixed :green_heart:")
+    end
+
+    it "does not send a message on passing builds" do
+      expect(subject).not_to receive(:gitter_send)
+      subject.send(:check, %w(passed passed), repository, branch)
+    end
+
+    it "does not send a message on failing builds" do
+      expect(subject).not_to receive(:gitter_send)
+      subject.send(:check, %w(failed failed), repository, branch)
+    end
+  end
+
+  describe "#latest_builds" do
+    let(:first_expected_build) { double("Build", :state => "passed", :branch_info => branch) }
+    let(:second_expected_build) { double("Build", :state => "failed", :branch_info => branch) }
+
+    let(:valid_unexpected_build) { double("Build", :state => "state", :branch_info => branch) }
+    let(:invalid_unexpected_build) { double("Build", :state => "state", :branch_info => "wrong branch") }
+
+    let(:travis_repository) { double("Travis::Repository", :builds => [first_expected_build, invalid_unexpected_build, second_expected_build, valid_unexpected_build]) }
+
+    it "should return the state of the last two builds" do
+      allow(Travis::Repository).to receive(:find).with(repository).and_return(travis_repository)
+
+      expect(subject.send(:latest_builds, repository, branch)).to eq([first_expected_build.state, second_expected_build.state])
+    end
+  end
+
+  describe "#gitter_send" do
+    let(:message) { "hello" }
+    let(:gitter_token) { "token" }
+    let(:gitter_rooms) { [double("Room", :name => "wrong1", :id => 1), double("Room", :name => room, :id => 2), double("Room", :name => "wrong2", :id => 3)] }
+    let(:gitter_client) { double("Gitter::Client", :rooms => gitter_rooms) }
+
+    it "sends a message" do
+      allow(Gitter::Client).to receive(:new).with(gitter_token).and_return(gitter_client)
+
+      expect(gitter_client).to receive(:send_message).with(message, 2)
+
+      subject.send(:gitter_send, room, message, gitter_token)
+    end
+  end
+end


### PR DESCRIPTION
A new feature "*notify gitter room members about repository branch fix/break*" was added. It is performed via gem [ruby-gitter](https://github.com/kristenmills/ruby-gitter).

A new worker is checking the state of latest two builds from which is stated the action for notification. Every 10 minutes worker gets the latest two builds of a specified branch in a specified repository from which is the state of the build obtained. The state of these builds decides about sending a message to a specified room on gitter. The judgement about broken branch is created when the states are [failed, passed] (first element of the array is the latest build state). The judgement about fixed branch is created when the states are [passed, failed]. Otherwise, when the states are [passed, passed] or [failed, failed] there is no action performed.  The required specification (gitter token, repository, branch, gitter room) must be included in the file containing the settings.

```yaml
travis_monitor:
  gitter_token: "****************************************"
  branches:
    - repo: "owner/name"
      branch: "name"
      gitter_room: "owner/name"
    - repo: "owner/name"
      branch: "name"
      gitter_room: "owner/name"
    - repo: "owner/name"
      branch: "name"
      gitter_room: "owner/name"
```

#### Gitter notification message:
* broken branch:

  :sos: :warning: "branch" in "owner/repository" is broken :bangbang: :boom:


* fixed branch:

  :white_check_mark: Broken branch has been fixed :green_heart:


\cc
@skateman