### PR TITLE
Remove unnecessary unmergeable comments

### DIFF
--- a/spec/workers/pr_mergeability_checker_spec.rb
+++ b/spec/workers/pr_mergeability_checker_spec.rb
@@ -33,15 +33,25 @@ describe PrMergeabilityChecker do
   end
 
   context 'when PR was unmergeable and becomes mergeable' do
+    let(:username) { "tux" }
+    let(:user) { double("User", :id => 42, :login => username) }
+    let(:body) { "<pr-mergeability-checker />This pull request is not mergeable.  Please rebase and repush." }
+    let(:comment) { double("Comment", :id => 9, :body => body, :user => user) }
     let(:pr_branch) { create(:pr_branch, :name => 'prs/1/head', :mergeable => false) }
 
-    it "removes an 'unmergeable' label from the PR" do
+    before do
+      stub_settings(Hash(:github_credentials => {:username => username}))
+    end
+
+    it "removes an 'unmergeable' label and comments from the PR" do
       git_service = instance_double('GitService::Branch', :mergeable? => true)
+
       allow(GitService::Branch).to receive(:new) { git_service }
       allow(GithubService).to receive(:add_comment)
 
-      expect(GithubService).to receive(:remove_label)
-        .with(repo_name, 1, 'unmergeable')
+      expect(GithubService).to receive(:remove_label).with(repo_name, 1, 'unmergeable')
+      expect(GithubService).to receive(:issue_comments).with(repo_name, 1).and_return([comment, comment])
+      expect(GithubService).to receive(:delete_comments).with(repo_name, [9, 9]).once
 
       described_class.new.perform(pr_branch.id)
     end


### PR DESCRIPTION
Except of label deletion the bot also deletes the comments describing unmergeable status of the pull request.

#### Comments to delete (example):
![image](https://user-images.githubusercontent.com/22373707/37771903-4944368c-2dd9-11e8-914d-c03ff420737e.png)

\cc
@skateman 
@romanblanco