### PR TITLE
Fix of issues in remove_reviewer command

### DIFF
--- a/lib/github_service/commands/remove_reviewer.rb
+++ b/lib/github_service/commands/remove_reviewer.rb
@@ -19,7 +19,7 @@ module GithubService
 
       # returns an array of user logins who were requested for a pull request review
       def requested_reviewers
-        GithubService.pull_request_review_requests(fq_repo_name, number).users.map(&:login)
+        GithubService.pull_request_review_requests(issue.fq_repo_name, issue.number).users.map(&:login)
       end
     end
   end

--- a/lib/github_service/commands/remove_reviewer.rb
+++ b/lib/github_service/commands/remove_reviewer.rb
@@ -8,7 +8,13 @@ module GithubService
 
         if valid_assignee?(user)
           if requested_reviewers.include?(user)
-            issue.remove_reviewer(user)
+            # FIXME: waiting for merge of https://github.com/octokit/octokit.rb/pull/990
+            begin
+              issue.remove_reviewer(user)
+            rescue NoMethodError
+              issue.add_comment("@#{issuer} `remove_reviewer [@]user` is currently not working, waiting for merge"\
+                                " of [dependent pull request](https://github.com/octokit/octokit.rb/pull/990)!")
+            end
           else
             issue.add_comment("@#{issuer} '#{user}' is not in the list of requested reviewers, ignoring...")
           end


### PR DESCRIPTION
The merge of https://github.com/ManageIQ/miq_bot/pull/411 can cause undesirable problems.

In [`lib/github_service/commands/remove_reviewer.rb`](https://github.com/europ/miq_bot/blob/7c3e7b46817aeae841ea847e30a39e08935e6286/lib/github_service/commands/remove_reviewer.rb) is an method missing error due to a dependent https://github.com/octokit/octokit.rb/pull/990 which is not merged yet and also an undefined two local variables error which is due to wrong method call.

The errors `undefined local variable fq_repo_name` and `undefined local variable number` were fixed with correct calling as an issue method call.

The **`undefined method delete_pull_request_review_request`** error is solved via catching `NoMethodError` exception. The call of this method will inform the requester of `remove_reviewer` command that this command is currently not working and it will perform no action (only posting a github comment with this informative text). This is a **temporary solution** until merge of https://github.com/octokit/octokit.rb/pull/990.

---
### Errors
* undefined local variable fq_repo_name
```
2018-03-22T16:48:45.326Z 15110 TID-grjjui1pk GithubNotificationMonitorWorker JID-6d1eab0b08206f522c5b5f18 ERROR: undefined local variable or method `fq_repo_name' for #<GithubService::Commands::RemoveReviewer:0x00005607f6e7cd78>
2018-03-22T16:48:45.327Z 15110 TID-grjjui1pk GithubNotificationMonitorWorker JID-6d1eab0b08206f522c5b5f18 ERROR: /root/miq_bot/lib/github_service/commands/remove_reviewer.rb:28:in `requested_reviewers'
/root/miq_bot/lib/github_service/commands/remove_reviewer.rb:13:in `_execute'
/root/miq_bot/lib/github_service/commands/base.rb:33:in `execute!'
/root/miq_bot/lib/github_service/command_dispatcher.rb:36:in `block in dispatch!'
/root/miq_bot/lib/github_service/command_dispatcher.rb:26:in `each'
/root/miq_bot/lib/github_service/command_dispatcher.rb:26:in `dispatch!'
...
```

* undefined local variable number
```
2018-03-22T18:34:12.120Z 16901 TID-gnk6maz3k GithubNotificationMonitorWorker JID-350692fa2e343c95c4eb66d3 ERROR: undefined local variable or method `number' for #<GithubService::Commands::RemoveReviewer:0x00005576a6dd7da0>
2018-03-22T18:34:12.121Z 16901 TID-gnk6maz3k GithubNotificationMonitorWorker JID-350692fa2e343c95c4eb66d3 ERROR: /root/miq_bot/lib/github_service/commands/remove_reviewer.rb:22:in `requested_reviewers'
/root/miq_bot/lib/github_service/commands/remove_reviewer.rb:10:in `_execute'
/root/miq_bot/lib/github_service/commands/base.rb:33:in `execute!'
/root/miq_bot/lib/github_service/command_dispatcher.rb:36:in `block in dispatch!'
/root/miq_bot/lib/github_service/command_dispatcher.rb:26:in `each'
/root/miq_bot/lib/github_service/command_dispatcher.rb:26:in `dispatch!'
...
```

* undefined method delete_pull_request_review_request
```
2018-03-22T17:26:27.343Z 16084 TID-gscdlbkhc GithubNotificationMonitorWorker JID-0abb1835ec1b698abd2c5769 ERROR: undefined method `delete_pull_request_review_request' for GithubService:Module
2018-03-22T17:26:27.343Z 16084 TID-gscdlbkhc GithubNotificationMonitorWorker JID-0abb1835ec1b698abd2c5769 ERROR: /root/miq_bot/lib/github_service.rb:158:in `method_missing'
/root/miq_bot/lib/github_service/issue.rb:18:in `remove_reviewer'
/root/miq_bot/lib/github_service/commands/remove_reviewer.rb:11:in `_execute'
/root/miq_bot/lib/github_service/commands/base.rb:33:in `execute!'
/root/miq_bot/lib/github_service/command_dispatcher.rb:36:in `block in dispatch!'
/root/miq_bot/lib/github_service/command_dispatcher.rb:26:in `each'
/root/miq_bot/lib/github_service/command_dispatcher.rb:26:in `dispatch!'
...
```

\cc
@Fryguy 
@skateman