### PR TITLE
Added missing linter into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ The ManageIQ bot is the ManageIQ team's helper to automate various developer pro
   - Detection of changes to a product's Gemfile, and setting a label.
 - GitHub pull request monitoring
   - Label and comment on a PR when it becomes unmergeable.
-  - Run [Rubocop](https://github.com/bbatsov/rubocop) and
-    [haml-lint](https://github.com/brigade/haml-lint) against a PR diff and
-    comment on any offenses found.
+  - Run [Rubocop](https://github.com/bbatsov/rubocop),
+    [haml-lint](https://github.com/brigade/haml-lint) and
+    [yamllint](https://yamllint.readthedocs.io/en/stable/index.html)
+    against a PR diff and comment on any offenses found.
 - Travis monitoring
   - Detecting stalled builds and automatically restarting them.
 


### PR DESCRIPTION
GitHub pull requests are also checked with yamllint [here](https://github.com/ManageIQ/miq_bot/blob/master/app/workers/concerns/code_analysis_mixin.rb#L26). Yamllint is also a miq_bot's dependency defined in the [setup](https://github.com/ManageIQ/miq_bot#setup).

![image](https://user-images.githubusercontent.com/22373707/38299444-6366aa6a-37fa-11e8-8238-877771ad1d1a.png)
