### PR TITLE
Command add_reviewer supports multiple users

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ underscores replaced with hyphens.
 
 - **`add_reviewer [@]user`**
   Request for pull request review the specified user. The leading `@` for the
-  user is optional. The user must be in the Assignees list.
+  user is optional. The users must be separated by a comma and they must be
+  in the Assignees list.
 
-  Example: `@miq-bot add_reviewer @user`
+  Example: `@miq-bot add_reviewer @user1[, @user2]`
 
 - **`remove_reviewer [@]user`**
   Remove a request for pull request review from the specified user. The leading `@` for the

--- a/lib/github_service/commands/add_reviewer.rb
+++ b/lib/github_service/commands/add_reviewer.rb
@@ -4,12 +4,18 @@ module GithubService
       private
 
       def _execute(issuer:, value:)
-        user = value.strip.delete('@')
+        users = value.strip.delete('@').split(/\s*,\s*/)
 
-        if valid_assignee?(user)
-          issue.add_reviewer(user)
-        else
-          issue.add_comment("@#{issuer} '#{user}' is an invalid reviewer, ignoring...")
+        valid_users, invalid_users = users.partition { |u| valid_assignee?(u) }
+
+        if valid_users.any?
+          issue.add_reviewer(valid_users)
+        end
+
+        if invalid_users.any?
+          message = "@#{issuer} Cannot add the following #{"reviewer".pluralize(invalid_users.size)} because they are not recognized: "
+          message << invalid_users.join(", ")
+          issue.add_comment(message)
         end
       end
     end

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -10,8 +10,8 @@ module GithubService
       GithubService.update_issue(fq_repo_name, number, "assignee" => user)
     end
 
-    def add_reviewer(user)
-      GithubService.request_pull_request_review(fq_repo_name, number, [user]) if pull_request?
+    def add_reviewer(users)
+      GithubService.request_pull_request_review(fq_repo_name, number, users) if pull_request?
     end
 
     def remove_reviewer(user)

--- a/spec/lib/github_service/commands/add_reviewer_spec.rb
+++ b/spec/lib/github_service/commands/add_reviewer_spec.rb
@@ -18,7 +18,15 @@ RSpec.describe GithubService::Commands::AddReviewer do
     let(:command_value) { "good_user" }
 
     it "review request that user" do
-      expect(issue).to receive(:add_reviewer).with("good_user")
+      expect(issue).to receive(:add_reviewer).with(["good_user"])
+    end
+  end
+
+  context "with a valid users" do
+    let(:command_value) { "good_user, good_user" }
+
+    it "review request that user" do
+      expect(issue).to receive(:add_reviewer).with(%w(good_user good_user))
     end
   end
 
@@ -27,7 +35,16 @@ RSpec.describe GithubService::Commands::AddReviewer do
 
     it "does not review request, reports failure" do
       expect(issue).not_to receive(:add_reviewer)
-      expect(issue).to receive(:add_comment).with("@#{command_issuer} 'bad_user' is an invalid reviewer, ignoring...")
+      expect(issue).to receive(:add_comment).with("@#{command_issuer} Cannot add the following reviewer because they are not recognized: bad_user")
+    end
+  end
+
+  context "with an invalid users" do
+    let(:command_value) { "bad_user, bad_user" }
+
+    it "does not review request, reports failure" do
+      expect(issue).not_to receive(:add_reviewer)
+      expect(issue).to receive(:add_comment).with("@#{command_issuer} Cannot add the following reviewers because they are not recognized: bad_user, bad_user")
     end
   end
 end


### PR DESCRIPTION
The commands add_reviewer or add_reviewers supports pull request review request for multiple users.

Command has a restriction for the users - they must be **separated by a comma**. 

The bot is able to perform these following commands:
`@bot add_reviewer @user`
`@bot add_reviewers @user`
`@bot add_reviewer @user1, @user2`
`@bot add_reviewers @user1, @user2`
`@bot add_reviewers @user1         ,@user2`
`@bot add_reviewers @user1,         @user2`
`@bot add_reviewers @user1         ,         @user2`

<br>

The separation between specified users is defined by regular expression `/\s*,\s*/` - the comma is required and the white spaces are optional. 

<br>

\cc @skateman 