### PR TITLE
Remove_reviewer implemented without dependence

### DIFF
--- a/lib/github_service/commands/remove_reviewer.rb
+++ b/lib/github_service/commands/remove_reviewer.rb
@@ -19,7 +19,7 @@ module GithubService
 
       # returns an array of user logins who were requested for a pull request review
       def requested_reviewers
-        GithubService.pull_request_review_requests(fq_repo_name, number).users.map(&:login)
+        GithubService.pull_request_review_requests(issue.fq_repo_name, issue.number).users.map(&:login)
       end
     end
   end

--- a/lib/github_service/commands/remove_reviewer.rb
+++ b/lib/github_service/commands/remove_reviewer.rb
@@ -12,8 +12,8 @@ module GithubService
             begin
               issue.remove_reviewer(user)
             rescue NoMethodError
-              issue.add_comment("@#{issuer} `remove_reviewer [@]user` is currently not working, waiting for merge"\
-                                " of [dependent pull request](https://github.com/octokit/octokit.rb/pull/990)!")
+              # TODO: Remove this exception handling after dependence merge.
+              octokit_request_pull_request_review(issue.fq_repo_name, issue.number, "reviewers" => [user])
             end
           else
             issue.add_comment("@#{issuer} '#{user}' is not in the list of requested reviewers, ignoring...")
@@ -26,6 +26,13 @@ module GithubService
       # returns an array of user logins who were requested for a pull request review
       def requested_reviewers
         GithubService.pull_request_review_requests(issue.fq_repo_name, issue.number).users.map(&:login)
+      end
+
+      # TODO: Remove this.
+      def octokit_request_pull_request_review(repo, id, reviewers, options = {})
+        service = GithubService.instance_variable_get("@service")
+        options = options.merge(:reviewers => reviewers.values.flatten)
+        service.delete("repos/#{repo}/pulls/#{id}/requested_reviewers", options)
       end
     end
   end

--- a/lib/github_service/commands/remove_reviewer.rb
+++ b/lib/github_service/commands/remove_reviewer.rb
@@ -8,7 +8,13 @@ module GithubService
 
         if valid_assignee?(user)
           if requested_reviewers.include?(user)
-            issue.remove_reviewer(user)
+            # FIXME: waiting for merge of https://github.com/octokit/octokit.rb/pull/990
+            begin
+              issue.remove_reviewer(user)
+            rescue NoMethodError
+              issue.add_comment("@#{issuer} `remove_reviewer [@]user` is currently not working, waiting for merge"\
+                                " of [dependent pull request](https://github.com/octokit/octokit.rb/pull/990)!")
+            end
           else
             issue.add_comment("@#{issuer} '#{user}' is not in the list of requested reviewers, ignoring...")
           end


### PR DESCRIPTION
### Closes https://github.com/ManageIQ/miq_bot/pull/416

The exception handling in the https://github.com/ManageIQ/miq_bot/pull/416 was replaced with a temporary solution until merge of https://github.com/octokit/octokit.rb/pull/990.

\cc
@Fryguy 
@skateman 
