### PR TITLE
unassign command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ underscores replaced with hyphens.
 
   Example: `@miq-bot assign @user`
 
+- **`unassign [@]user`**
+  Unassign the issue or pull request to the specified user(s). The leading `@` for the
+  user is optional. The user(s) must be assigned to the issue or pull request and they
+  must be comma separated.
+
+  Example: `@miq-bot unassign @user1[, @user2]`
+
 - **`add_reviewer [@]user`**
   Request for pull request review the specified user. The leading `@` for the
   user is optional. The user must be in the Assignees list.

--- a/lib/github_notification_monitor.rb
+++ b/lib/github_notification_monitor.rb
@@ -10,6 +10,7 @@ class GithubNotificationMonitor
     "remove_label"    => :remove_labels,
     "rm_label"        => :remove_labels,
     "assign"          => :assign,
+    "unassign"        => :unassign,
     "add_reviewer"    => :add_reviewer,
     "remove_reviewer" => :remove_reviewer,
     "set_milestone"   => :set_milestone

--- a/lib/github_service/commands/unassign.rb
+++ b/lib/github_service/commands/unassign.rb
@@ -1,0 +1,35 @@
+module GithubService
+  module Commands
+    class Unassign < Base
+      private
+
+      def _execute(issuer:, value:)
+        users = value.strip.delete('@').split(/\s*,\s*/)
+
+        assgined_users = list_assigned_users
+
+        valid_users, invalid_users = users.partition { |u| assgined_users.include?(u) }
+
+        if valid_users.any?
+          octokit_remove_assignees(issue.fq_repo_name, issue.number, valid_users)
+        end
+
+        if invalid_users.any?
+          message = "@#{issuer} #{"User".pluralize(invalid_users.size)} '#{invalid_users.join(", ")}' #{invalid_users.size == 1 ? "is" : "are"} not in the list of assignees, ignoring..."
+          issue.add_comment(message)
+        end
+      end
+
+      def list_assigned_users
+        GithubService.issue(issue.fq_repo_name, issue.number).assignees.map(&:login)
+      end
+
+      # FIXME: NoMethodError on `remove_assignees`
+      # https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/issues.rb#L346
+      def octokit_remove_assignees(repo, number, assignees, options = {})
+        service = GithubService.instance_variable_get("@service")
+        service.delete("repos/#{repo}/issues/#{number}/assignees", options.merge(:assignees => assignees))
+      end
+    end
+  end
+end

--- a/spec/lib/github_service/commands/unassign_spec.rb
+++ b/spec/lib/github_service/commands/unassign_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe GithubService::Commands::Unassign do
+  subject { described_class.new(issue) }
+  let(:issue) { double("Issue", :fq_repo_name => "org/repo") }
+  let(:command_issuer) { "nickname" }
+  let(:assigned_users) { ["listed_user"] }
+
+  before do
+    allow(subject).to receive(:list_assigned_users).and_return(assigned_users)
+  end
+
+  after do
+    subject.execute!(:issuer => command_issuer, :value => command_value)
+  end
+
+  context "with a user who is in the list of assignees" do
+    let(:command_value) { "listed_user" }
+
+    it "unassigns pull request or issue from that user" do
+      allow(issue).to receive(:number).and_return(42)
+      expect(subject).to receive(:octokit_remove_assignees).with("org/repo", 42, %w(listed_user)).once
+    end
+  end
+
+  context "with a user who is not in the list of assignees" do
+    let(:command_value) { "non_listed_user" }
+
+    it "do not unassign pull request or issue from that user" do
+      expect(issue).not_to receive(:octokit_remove_assignees)
+      expect(issue).to receive(:add_comment).with("@#{command_issuer} User 'non_listed_user' is not in the list of assignees, ignoring...")
+    end
+  end
+
+  context "with users who are in the list of assignees" do
+    let(:assigned_users) { %w(listed_user1 listed_user2) }
+    let(:command_value) { "listed_user1, listed_user2" }
+
+    it "unassigns pull request or issue from these users" do
+      allow(issue).to receive(:number).and_return(42)
+      expect(subject).to receive(:octokit_remove_assignees).with("org/repo", 42, %w(listed_user1 listed_user2)).once
+    end
+  end
+
+  context "with users who are not in the list of assignees" do
+    let(:assigned_users) { %w(listed_user1 listed_user2) }
+    let(:command_value) { "non_listed_user1, non_listed_user2" }
+
+    it "do not unassign pull request or issue from these users" do
+      expect(issue).not_to receive(:octokit_remove_assignees)
+      expect(issue).to receive(:add_comment).with("@#{command_issuer} Users 'non_listed_user1, non_listed_user2' are not in the list of assignees, ignoring...")
+    end
+  end
+end


### PR DESCRIPTION
### Closes: https://github.com/ManageIQ/miq_bot/issues/134

A new command was added by which can be users unassigned from an issue or pull request. The command supports multiple users in a comma separated notation. The specified users must be in the list of assignees.
 
#### Example:
![unassign](https://user-images.githubusercontent.com/22373707/39100464-379ac016-468b-11e8-8040-c08789fc8ac9.png)

\cc
@skateman
@Fryguy
