### PR TITLE
Update Rubocop to add compatibility with new rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'awesome_spawn',        '>= 1.4.1'
 gem 'default_value_for'
 gem 'haml_lint',            '~> 0.20.0', :require => false
 gem 'more_core_extensions', '~> 2.0.0',  :require => 'more_core_extensions/all'
-gem 'rubocop',              '~> 0.52.0', :require => false
+gem 'rubocop',              '~> 0.53.0', :require => false
 gem 'rugged',                            :require => false
 
 gem 'octokit', '~> 4.8.0', :require => false


### PR DESCRIPTION
At [version`0.53.0`](https://github.com/bbatsov/rubocop/blob/3c3e315b84df45845440a25cbd71a5b99214b21d/CHANGELOG.md#0530-2018-03-05), the `TrailingCommaInLiteral` rule at Rubocop has been split into`TrailingCommaInHashLiteral` and `TrailingCommaInArrayLiteral` and no longer exists. The current version definition for Rubocop allow us to use the version `0.52.1` or superior, but it is not possible to have both versions by having that options in your `rubocop.yml` file.

In order to use the new updated rules, this PR updates the current rubocop version to `0.53.0`.

Should be merged with:
- https://github.com/ManageIQ/guides/pull/303