### PR TITLE
Remove active_bugzilla

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ gem 'sinatra', :require => false
 gem 'slim'
 
 # Services gems
-gem 'active_bugzilla'
 gem 'minigit',        '~> 0.0.4'
 gem 'tracker_api',    '~> 1.6'
 gem 'travis',         '~> 1.7.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,6 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_bugzilla (1.0.1)
-      activemodel
-      activesupport
-      dirty_hashy
     activejob (4.2.10)
       activesupport (= 4.2.10)
       globalid (>= 0.3.0)
@@ -93,8 +89,6 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
-    dirty_hashy (0.2.1)
-      activesupport
     dotenv (0.7.0)
     equalizer (0.0.11)
     erubis (2.7.0)
@@ -359,7 +353,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_bugzilla
   awesome_spawn (>= 1.4.1)
   coffee-rails (~> 4.0.0)
   config

--- a/app/workers/commit_monitor_handlers/commit_range/bugzilla_pr_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/bugzilla_pr_checker.rb
@@ -32,7 +32,6 @@ module CommitMonitorHandlers
 
             add_pr_comment(bug)
             update_bug_status(bug)
-            bug.save
           end
         end
       end
@@ -53,8 +52,8 @@ module CommitMonitorHandlers
       end
 
       def bug_has_pr_uri_comment?(bug)
-        bug.comments.any? do |c|
-          c.text.include?(@branch.github_pr_uri)
+        bug.comments.any? do |comment_text|
+          comment_text.include?(@branch.github_pr_uri)
         end
       end
 
@@ -63,6 +62,7 @@ module CommitMonitorHandlers
         when "NEW", "ASSIGNED"
           logger.info "Changing status of bug #{bug.id} to ON_DEV."
           bug.status = "ON_DEV"
+          bug.save
         else
           logger.info "Not changing status of bug #{bug.id} due to status of #{bug.status}"
         end

--- a/config/initializers/services_initializer.rb
+++ b/config/initializers/services_initializer.rb
@@ -1,4 +1,5 @@
 unless Rails.env.test?
   BugzillaService.credentials = Settings.bugzilla_credentials
+  BugzillaService.product     = Settings.bugzilla.product
   PivotalService.credentials  = Settings.pivotal_credentials
 end

--- a/lib/bugzilla_service.rb
+++ b/lib/bugzilla_service.rb
@@ -1,5 +1,5 @@
 class BugzillaService
-  include ThreadsafeServiceMixin
+  include ServiceMixin
 
   CLOSING_KEYWORDS = %w(
     close
@@ -13,24 +13,136 @@ class BugzillaService
     resolved
   )
 
-  def initialize
-    service # initialize the service
+  class << self
+    attr_reader :product
+
+    def product=(product)
+      if product.present?
+        @product = product
+      else
+        raise "Please set a Bugzilla product in config/settings!"
+      end
+    end
+
+    def credentials=(credentials)
+      if credentials.username.present? || credentials.password.present?
+        @credentials = credentials
+      else
+        raise "username and password must be set in config/settings"
+      end
+    end
   end
 
-  def service
-    @service ||= begin
-      require 'active_bugzilla'
-      bz = ActiveBugzilla::Service.new(*credentials.to_h.values_at(:url, :username, :password))
-      ActiveBugzilla::Base.service = bz
+  # Helper class for specific bugs
+  class Bug
+    attr_reader   :service
+    attr_accessor :id, :status
+
+    def initialize(service, id, status)
+      @service, @id, @status = service, id, status
+    end
+
+    def comments
+      response = service.get("/rest/bug/#{id}/comment") do |req|
+        req.params["include_fields"] = "text"
+      end
+
+      if response.status == 200
+        JSON.parse(response.body)["bugs"][id.to_s]["comments"]
+            .map { |comment| comment["text"] }
+      else
+        []
+      end
+    end
+
+    # Adds a comment.  Returns true if status == 200
+    def add_comment(text)
+      payload  = {"comment" => text}.to_json
+      response = service.post("/rest/bug/#{id}/comment", payload)
+
+      response.status == 200
+    end
+
+    # Basicially API compatible with `active_bugzilla` way of updating the bug
+    # status.
+    def save
+      payload  = { "ids" => [id], "status" => status }.to_json
+      response = service.put("/rest/bug/#{id}", payload)
+
+      response.status == 200
+    end
+  end
+
+  def initialize
+    connection # initialize the connection
+  end
+
+  def connection
+    @connection ||= begin
+      require 'faraday'
+
+      Faraday.new(:url => credentials.to_h[:url]) do |faraday|
+        faraday.request(:url_encoded)
+        faraday.adapter(Faraday.default_adapter)
+      end
     end
   end
 
   def find_bug(id)
-    ActiveBugzilla::Bug.find(:product => Settings.bugzilla.product, :id => id).first
+    response = get("/rest/bug") do |req|
+      req.params["id"]             = id
+      req.params["product"]        = self.class.product
+      req.params["include_fields"] = "id,status"
+    end
+
+    if response.status == 200
+      attributes = JSON.parse(response.body)["bugs"].first
+      Bug.new(self, attributes['id'], attributes['status'])
+    end
   end
 
   def with_bug(id)
     yield find_bug(id)
+  end
+
+  # Shared request helpers for adding BZ auth to a request
+  def get(path, &block)
+    connection.get(&faraday_request_block(path, &block))
+  end
+
+  def post(path, payload, &block)
+    connection.post(&put_post_block(path, payload, &block))
+  end
+
+  def put(path, payload, &block)
+    connection.put(&put_post_block(path, payload, &block))
+  end
+
+  private
+
+  # Shared request block for adding the URL and block (required for both GET
+  # and POST requests)
+  def faraday_request_block(path)
+    lambda do |req|
+      req.url(path)
+      req.params["login"]    = credentials.username
+      req.params["password"] = credentials.password
+
+      yield req if block_given?
+    end
+  end
+
+  # Double block nesting...
+  #
+  # Adds both auth from faraday_request_block, and sets body for the POST
+  # payload, and passes the block twice (technically)
+  def put_post_block(path, payload)
+    faraday_request_block(path) do |req|
+      req.headers["Content-Type"] = "application/json"
+      req.body = payload
+
+      yield if block_given?
+    end
   end
 
   def self.ids_in_git_commit_message(message)


### PR DESCRIPTION
Replaced with some inline http calls via Faraday.  Uses the REST API, since the XMLRPC API has been deprecated and removed in BZ 5.0, and the bits needed for this app are small enough to not warrant trying to get all of `active_bugzilla` up to to code with the new API format.

Mostly marked [WIP] at this point because I haven't tested the PUT/POST actions.


Links
-----

* API docs specific to RedHat Bugzilla:
  - https://bugzilla.redhat.com/docs/en/html/api/core/v1/general.html (for authentication)
  - https://bugzilla.redhat.com/docs/en/html/api/core/v1/bug.html (GET/PUT bugs)
  - https://bugzilla.redhat.com/docs/en/html/api/core/v1/comment.html (GET/CREATE comments)


QA
--

Just a command line way to test the `GET` requests in the `BugzillaService`

1. Setup your bugzilla settings in `config/settings/development.yml`:
   
   ```yaml
   bugzilla_credentials:
     url: https://bugzilla.redhat.com
     username: "YOUR_USERNAME"
     password: "YOUR_PASSWORD"
   bugzilla:
   product: "Red Hat CloudForms Management Engine"
   ```
   
2. Run the following in the app dir with the branch checked out (make sure to `bundle` and such, and update the `1234567` with an ID of a valid BZ ID)
   
   ```console
   $ bin/rails runner "BugzillaService.call {|service| puts service.find_bug(1234567).inspect }" # fetch a bug
   $ bin/rails runner "BugzillaService.call {|service| puts service.find_bug(1234567).comments.inspect }" # fetch comments for that bug
   ```