### PR TITLE
[super wip don't even look at it] Add command to test repos with the cross-repo tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ underscores replaced with hyphens.
 
   Example: `@miq-bot remove_reviewer @user`
 
+- **`run-tests [<repos-to-test>] [including <gem-repos>]`**
+  Test pull request against specified repos of the form [org/]repo[@ref|#pr].
+
+  * repos-to-test arg is a comma-separated list of repos
+  * gem-repos is a set of gem repos
+  * only works on PRs, and will fail on issues
+  * is only executable by the PR author or any member of the ManageIQ org
+
+  Example: `@miq-bot run-tests manageiq-ui-classic`
+
 - **`set_milestone milestone_name`**
   Set the specified milestone on the issue. Do not wrap the
   milestone in quotes.

--- a/lib/github_notification_monitor.rb
+++ b/lib/github_notification_monitor.rb
@@ -9,6 +9,7 @@ class GithubNotificationMonitor
     "add_label"       => :add_labels,
     "remove_label"    => :remove_labels,
     "rm_label"        => :remove_labels,
+    "run-test"        => :run_tests,
     "assign"          => :assign,
     "add_reviewer"    => :add_reviewer,
     "remove_reviewer" => :remove_reviewer,

--- a/spec/lib/github_service/command_dispatcher_spec.rb
+++ b/spec/lib/github_service/command_dispatcher_spec.rb
@@ -66,5 +66,16 @@ RSpec.describe GithubService::CommandDispatcher do
           .with(:issuer => command_issuer, :value => "question")
       end
     end
+
+    context "when 'run_tests' command is given" do
+      let(:text) { "@#{bot_name} run-tests manageiq-ui-classic" }
+      let(:command_class) { double }
+
+      it "dispatches to RunTests" do
+        expect(GithubService::Commands::RunTests).to receive(:new).and_return(command_class)
+        expect(command_class).to receive(:execute!)
+          .with(:issuer => command_issuer, :command => "run-tests", :value => "manageiq-ui-classic")
+      end
+    end
   end
 end


### PR DESCRIPTION
Adding a bot action to test with the cross-repo magic.

It's a README change, don't look at it. I was just excited because it's freaking sweet. 

https://github.com/ManageIQ/miq_bot/issues/446