### PR TITLE
[Linter::Base] Fix rubucop file permission check

### DIFF
--- a/lib/linter/base.rb
+++ b/lib/linter/base.rb
@@ -56,9 +56,14 @@ module Linter
       content = branch_service.content_at(path, merged)
       return false unless content
 
+      perm      = branch_service.permission_for(path, merged)
       temp_file = File.join(destination_dir, path)
       FileUtils.mkdir_p(File.dirname(temp_file))
-      File.write(temp_file, content, :mode => "wb") # To prevent Encoding::UndefinedConversionError: "\xD0" from ASCII-8BIT to UTF-8
+
+      # Use "wb" to prevent Encoding::UndefinedConversionError: "\xD0" from
+      # ASCII-8BIT to UTF-8
+      File.write(temp_file, content, :mode => "wb", :perm => perm)
+
       true
     end
 


### PR DESCRIPTION
Addresses: https://github.com/ManageIQ/miq_bot/issues/445

When checking out the contents of the file to run linters against use Rugged, the content was just copied to a new file without taking into account the permissions that are set in the repository object.

This fix now performs a check and creates a file matching the permissions found in the repo being linted.


@miq-bot assign @bdunne