### PR TITLE
MiqBot AutoCorrect for AddLabel

### DIFF
--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -64,8 +64,5 @@ module GithubService
   end
 end
 
-# Travis HACK v2
-begin
-  String.methosd
-rescue NoMethodError
-end
+# Travis HACK v2 (debugging)
+String.methosd

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -64,20 +64,17 @@ module GithubService
   end
 end
 
-# Travis HACK v2 (debugging)
-#
-#
-
-puts
-puts
-pp ENV
-puts
-puts
-pp RbConfig::CONFIG
-puts
-puts
-pp $LOAD_PATH
-puts
-puts
-
-String.methosd
+# HACK: Travis / `bundle install --path ...` compat
+begin
+  retry_require_dym = false
+  require 'did_you_mean'
+rescue LoadError => error
+  if retry_require_dym
+    raise error
+  else
+    $LOAD_PATH.push(*Dir[File.join(Gem.default_dir, "gems", "did_you_mean*", "lib")])
+    $LOAD_PATH.uniq!
+    retry_require_dym = true
+    retry
+  end
+end

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -76,5 +76,8 @@ puts
 pp RbConfig::CONFIG
 puts
 puts
+pp $LOAD_PATH
+puts
+puts
 
 String.methosd

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -1,5 +1,3 @@
-require 'did_you_mean' if ENV["TRAVIS"]
-
 module GithubService
   module Commands
     class AddLabel < Base
@@ -64,4 +62,10 @@ module GithubService
       end
     end
   end
+end
+
+# Travis HACK v2
+begin
+  String.methosd
+rescue NoMethodError
 end

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -65,4 +65,16 @@ module GithubService
 end
 
 # Travis HACK v2 (debugging)
+#
+#
+
+puts
+puts
+pp ENV
+puts
+puts
+pp RbConfig::CONFIG
+puts
+puts
+
 String.methosd

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -1,3 +1,5 @@
+require 'did_you_mean' if ENV["TRAVIS"]
+
 module GithubService
   module Commands
     class AddLabel < Base

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -56,8 +56,9 @@ module GithubService
 
           message << "* `#{bad_label}` "
           message << "(Did you mean? #{possibilities})" if corrections.any?
+          message << "\n"
         end
-        message
+        message << "\nAll labels for `#{issue.fq_repo_name}`:  https://github.com/#{issue.fq_repo_name}/labels"
       end
     end
   end

--- a/spec/lib/github_service/commands/add_label_spec.rb
+++ b/spec/lib/github_service/commands/add_label_spec.rb
@@ -3,15 +3,18 @@ require 'spec_helper'
 RSpec.describe GithubService::Commands::AddLabel do
   subject { described_class.new(issue) }
   let(:issue) { double(:fq_repo_name => "foo/bar") }
+  let(:labels) { %w[question wontfix] }
   let(:command_issuer) { "chessbyte" }
   let(:command_value) { "question, wontfix" }
 
   before do
     allow(issue).to receive(:applied_label?).with("question").and_return(true)
     allow(issue).to receive(:applied_label?).with("wontfix").and_return(false)
-    %w(question wontfix).each do |label|
+    allow(GithubService).to receive(:labels).with(issue.fq_repo_name).and_return(labels)
+    labels.each do |label|
       allow(GithubService).to receive(:valid_label?).with("foo/bar", label).and_return(true)
     end
+    allow(GithubService).to receive(:valid_label?).with("foo/bar", "wont fix").and_return(false)
   end
 
   after do
@@ -20,6 +23,14 @@ RSpec.describe GithubService::Commands::AddLabel do
 
   context "with valid labels" do
     it "adds the unapplied labels" do
+      expect(issue).to receive(:add_labels).with(["wontfix"])
+    end
+  end
+
+  context "with slightly misspelled labels" do
+    let(:command_value) { "question, wont fix" }
+
+    it "corrects and adds the unapplied labels (if there is only one option)" do
       expect(issue).to receive(:add_labels).with(["wontfix"])
     end
   end

--- a/spec/lib/github_service/commands/add_label_spec.rb
+++ b/spec/lib/github_service/commands/add_label_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe GithubService::Commands::AddLabel do
         err_comment = <<~ERR.chomp
           @#{command_issuer} Cannot apply the following label because they are not recognized:
           * `wont fix` (Did you mean? `wontfix`, `wont-fix`)
+
+          All labels for `foo/bar`:  https://github.com/foo/bar/labels
         ERR
         expect(issue).to receive(:add_comment).with(err_comment)
       end

--- a/spec/lib/github_service/commands/add_label_spec.rb
+++ b/spec/lib/github_service/commands/add_label_spec.rb
@@ -33,6 +33,23 @@ RSpec.describe GithubService::Commands::AddLabel do
     it "corrects and adds the unapplied labels (if there is only one option)" do
       expect(issue).to receive(:add_labels).with(["wontfix"])
     end
+
+    context "with multiple options for misspellings" do
+      let(:labels) { %w[question wontfix wont-fix] }
+
+      it "does not add invalid labels" do
+        expect(issue).to receive(:add_comment)
+        expect(issue).not_to receive(:add_labels)
+      end
+
+      it "comments on error and provides corrections as options" do
+        err_comment = <<~ERR.chomp
+          @#{command_issuer} Cannot apply the following label because they are not recognized:
+          * `wont fix` (Did you mean? `wontfix`, `wont-fix`)
+        ERR
+        expect(issue).to receive(:add_comment).with(err_comment)
+      end
+    end
   end
 
   context "with invalid labels" do


### PR DESCRIPTION
Adds `DidYouMean` support to `GithubService::Commands::AddLabel`, which will auto correct invalid labels, or at the very least provide options for incorrect labels.

This PR does slightly change the format of "incorrect label" issue comments.


Links
-----

- "Inspiration":  https://gitter.im/ManageIQ/manageiq/core?at=5e29e4591a1c2739e3e8b85f