### PR TITLE
[StaleIssueMarker] Use GithubService.search_issues

### DIFF
--- a/app/workers/schedulers/stale_issue_marker.rb
+++ b/app/workers/schedulers/stale_issue_marker.rb
@@ -9,7 +9,7 @@ module Schedulers
     include SidekiqWorkerMixin
 
     def perform
-      enabled_repo_names.each { |r| ::StaleIssueMarker.perform_async(r) }
+      StaleIssueMarker.perform_async
     end
   end
 end

--- a/lib/github_service.rb
+++ b/lib/github_service.rb
@@ -42,6 +42,10 @@ module GithubService
     end
     alias issues list_issues
 
+    def search_issues(*args)
+      service.search_issues(*args).items.map { |issue| Issue.new(issue) }
+    end
+
     def issue_comments(*args)
       service.issue_comments(*args).map do |comment|
         IssueComment.new(comment)


### PR DESCRIPTION
This is a pretty large refactoring of the StaleIssueMarker, but makes use of the `search_issues` api to reduce the number of API calls required to run this worker.

As a side effect, it also simplifies each of the methods in the class so they are a bit easier to digest.

Links
-----

* Github `/search/issues` endpoint docs: https://developer.github.com/v3/search/#search-issues-and-pull-requests
* Original implementation:  https://github.com/ManageIQ/miq_bot/pull/331

The original implementation PR includes some design context that I think is worth being aware of when reviewing.