### PR TITLE
add_label/remove_label:  Prevent non-triage team assignment/removal

### DIFF
--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -1,6 +1,10 @@
 module GithubService
   module Commands
     class AddLabel < Base
+      UNASSIGNABLE = {
+        "jansa/yes" => "jansa/yes?"
+      }.freeze
+
       private
 
       def _execute(issuer:, value:)
@@ -32,6 +36,7 @@ module GithubService
 
       def process_extracted_labels(valid_labels, invalid_labels)
         correct_invalid_labels(valid_labels, invalid_labels)
+        handle_unassignable_labels(valid_labels)
 
         [valid_labels, invalid_labels]
       end
@@ -46,7 +51,12 @@ module GithubService
             valid_labels << corrections.first
           end
         end
+      end
 
+      def handle_unassignable_labels(valid_labels)
+        valid_labels.map! do |label|
+          UNASSIGNABLE.key?(label) ? UNASSIGNABLE[label] : label
+        end
       end
 
       def invalid_label_message(issuer, invalid_labels)

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -31,16 +31,22 @@ module GithubService
       end
 
       def process_extracted_labels(valid_labels, invalid_labels)
-        labels = GithubService.labels(issue.fq_repo_name)
+        correct_invalid_labels(valid_labels, invalid_labels)
+
+        [valid_labels, invalid_labels]
+      end
+
+      def correct_invalid_labels(valid_labels, invalid_labels)
+        available_labels = GithubService.labels(issue.fq_repo_name)
+
         invalid_labels.reject! do |label|
-          corrections = DidYouMean::SpellChecker.new(:dictionary => labels).correct(label)
+          corrections = DidYouMean::SpellChecker.new(:dictionary => available_labels).correct(label)
 
           if corrections.count == 1
             valid_labels << corrections.first
           end
         end
 
-        [valid_labels, invalid_labels]
       end
 
       def invalid_label_message(issuer, invalid_labels)

--- a/lib/github_service/commands/remove_label.rb
+++ b/lib/github_service/commands/remove_label.rb
@@ -1,16 +1,28 @@
 module GithubService
   module Commands
     class RemoveLabel < Base
+      UNREMOVABLE = %w[jansa/yes jansa/no].freeze
+
       alias_as 'rm_label'
 
       private
 
       def _execute(issuer:, value:)
+        unremovable    = []
         valid, invalid = extract_label_names(value)
+        process_extracted_labels(valid, invalid, unremovable)
 
         if invalid.any?
           message = "@#{issuer} Cannot remove the following label#{"s" if invalid.length > 1} because they are not recognized: "
           message << invalid.join(", ")
+          issue.add_comment(message)
+        end
+
+        if unremovable.any?
+          labels       = "label#{"s" if unremovable.length > 1}"
+          triage_perms = "[triage team permissions](https://github.com/orgs/ManageIQ/teams/core-triage)"
+          message      = "@#{issuer} Cannot remove the following #{labels} since they require #{triage_perms}: "
+          message << unremovable.join(", ")
           issue.add_comment(message)
         end
 
@@ -22,6 +34,11 @@ module GithubService
       def extract_label_names(value)
         label_names = value.split(",").map { |label| label.strip.downcase }
         validate_labels(label_names)
+      end
+
+      def process_extracted_labels(valid_labels, _invalid_labels, unremovable)
+        valid_labels.each { |label| unremovable << label if UNREMOVABLE.include?(label) }
+        unremovable.each  { |label| valid_labels.delete(label) }
       end
 
       def validate_labels(label_names)

--- a/spec/lib/github_service/commands/add_label_spec.rb
+++ b/spec/lib/github_service/commands/add_label_spec.rb
@@ -66,4 +66,18 @@ RSpec.describe GithubService::Commands::AddLabel do
       expect(issue).to receive(:add_comment).with(/Cannot apply the following label.*not recognized/)
     end
   end
+
+  context "un-assignable labels" do
+    let(:command_value) { "jansa/yes" }
+
+    before do
+      allow(issue).to receive(:applied_label?).with("jansa/yes?").and_return(false)
+      allow(GithubService).to receive(:valid_label?).with("foo/bar", command_value).and_return(true)
+    end
+
+    it "corrects the label to 'jansa/yes?'" do
+      expect(issue).to receive(:add_labels).with(["jansa/yes?"])
+      expect(issue).not_to receive(:add_comment)
+    end
+  end
 end


### PR DESCRIPTION
Starting with the Jansa release, we are changing the backport process to require code changes that are requesting a backport submit the `jansa/yes?` first to get approval from the triage team.  This means that setting the `jansa/yes` label (and similar labels from this release forward) will not be allowed.

For the purposes of the bot, this means that any labels that have been assigned a `*/yes` label (only `jansa/yes` for now), will be automatically converted to `jansa/yes?`.

Also, removing any of the `*/yes` and `*/no` labels is no longer possible via the bot, and the bot will respond with a warning if removing any of the `UNREMOVABLE` labels is attempted.


Links
-----

Fixes #475