### PR TITLE
[AddLabel/RemoveLabel] Allow triage team to add all labels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'travis',         '~> 1.7.6'
 gem 'awesome_spawn',        '>= 1.4.1'
 gem 'default_value_for',    '>= 3.1.0'
 gem 'haml_lint',            '~> 0.20.0', :require => false
-gem 'more_core_extensions', '~> 2.0.0',  :require => 'more_core_extensions/all'
+gem 'more_core_extensions', '~> 4.0.0',  :require => 'more_core_extensions/all'
 gem 'rubocop',              '~> 0.69.0', :require => false
 gem 'rubocop-performance',  '~> 1.3',    :require => false
 gem 'rugged',                            :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,8 +163,8 @@ GEM
     mini_portile2 (2.4.0)
     minigit (0.0.4)
     minitest (5.10.3)
-    more_core_extensions (2.0.0)
-      activesupport (> 3.2)
+    more_core_extensions (4.0.0)
+      activesupport
     multi_json (1.14.1)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
@@ -370,7 +370,7 @@ DEPENDENCIES
   jquery-rails
   listen
   minigit (~> 0.0.4)
-  more_core_extensions (~> 2.0.0)
+  more_core_extensions (~> 4.0.0)
   octokit (~> 4.8.0)
   pg
   rails (~> 4.2.4)

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ module MiqBot
     # config.i18n.default_locale = :de
 
     config.eager_load_paths << Rails.root.join("app/workers/concerns")
+    config.eager_load_paths << Rails.root.join("lib/github_service/concerns")
     config.eager_load_paths << Rails.root.join("lib")
 
     console do

--- a/lib/github_service/concerns/is_team_member.rb
+++ b/lib/github_service/concerns/is_team_member.rb
@@ -1,0 +1,36 @@
+module IsTeamMember
+  def triage_member?(username)
+    IsTeamMember.triage_team_members.include?(username)
+  end
+
+  # List of usernames for the traige team
+  #
+  # Cache triage_team_members, and refresh cache every 24 hours
+  #
+  # Note:  This is created as a class method
+  #
+  cache_with_timeout(:triage_team_members, 24 * 60 * 60) do
+    if member_organization_name && triage_team_name
+      team = GithubService.org_teams(member_organization_name)
+                          .detect { |t| t.name == triage_team_name }
+
+      if team.nil?
+        []
+      else
+        GithubService.team_members(team.id).map(&:login)
+      end
+    else
+      []
+    end
+  end
+
+  module_function
+
+  def triage_team_name
+    @triage_team_name ||= Settings.triage_team_name || nil
+  end
+
+  def member_organization_name
+    @member_organization_name ||= Settings.member_organization_name || nil
+  end
+end

--- a/spec/lib/github_service/commands/remove_label_spec.rb
+++ b/spec/lib/github_service/commands/remove_label_spec.rb
@@ -6,7 +6,21 @@ RSpec.describe GithubService::Commands::RemoveLabel do
   let(:command_issuer) { "chessbyte" }
   let(:command_value) { "question, wontfix" }
 
+  let(:miq_teams) do
+    [
+      {"id" => 1234, "name" => "commiters"},
+      {"id" => 2345, "name" => "core-triage"},
+      {"id" => 3456, "name" => "my-triage-team"},
+      {"id" => 4567, "name" => "UI"}
+    ]
+  end
+
   after do
+    # unset class variables (weird ordering thanks to @chrisarcand...)
+    [:@triage_team_name, :@member_organization_name].each do |var|
+      IsTeamMember.remove_instance_variable(var) if IsTeamMember.instance_variable_defined?(var)
+    end
+
     subject.execute!(:issuer => command_issuer, :value => command_value)
   end
 
@@ -46,7 +60,15 @@ RSpec.describe GithubService::Commands::RemoveLabel do
 
     context "with labels that are UNREMOVABLE" do
       # An invalid situation, just testing in one go
-      let(:command_value) { "wontfix, jansa/no, jansa/yes, jansa/yes?" }
+      let(:command_value)  { "wontfix, jansa/no, jansa/yes, jansa/yes?" }
+      let(:triage_members) { [{"login" => "Fryguy"}] }
+
+      before do
+        github_service_add_stub :url           => "/orgs/ManageIQ/teams?per_page=100",
+                                :response_body => miq_teams.to_json
+        github_service_add_stub :url           => "/teams/3456/members?per_page=100",
+                                :response_body => triage_members.to_json
+      end
 
       before do
         %w[wontfix jansa/no jansa/yes jansa/yes?].each do |label|
@@ -55,19 +77,64 @@ RSpec.describe GithubService::Commands::RemoveLabel do
 
         expect(issue).to receive(:applied_label?).with("wontfix").and_return(true)
         expect(issue).to receive(:applied_label?).with("jansa/yes?").and_return(true)
-
-        message = "@chessbyte Cannot remove the following labels since they require "              \
-                  "[triage team permissions](https://github.com/orgs/ManageIQ/teams/core-triage)" \
-                  ": jansa/no, jansa/yes"
-
-        expect(issue).to receive(:add_comment).with(message)
       end
 
-      it "only removes the applied label" do
-        expect(issue).to     receive(:remove_label).with("wontfix")
-        expect(issue).not_to receive(:remove_label).with("jansa/no")
-        expect(issue).not_to receive(:remove_label).with("jansa/yes")
-        expect(issue).to     receive(:remove_label).with("jansa/yes?")
+      context "without a triage team" do
+        before do
+          message = "@chessbyte Cannot remove the following labels since they require "              \
+                    "[triage team permissions](https://github.com/orgs/ManageIQ/teams/core-triage)" \
+                    ": jansa/no, jansa/yes"
+
+          expect(issue).to receive(:add_comment).with(message)
+        end
+
+        it "only removes the removable applied labels" do
+          expect(issue).to     receive(:remove_label).with("wontfix")
+          expect(issue).not_to receive(:remove_label).with("jansa/no")
+          expect(issue).not_to receive(:remove_label).with("jansa/yes")
+          expect(issue).to     receive(:remove_label).with("jansa/yes?")
+        end
+      end
+
+      context "with a triage team" do
+        before do
+          message = "@chessbyte Cannot remove the following labels since they require "              \
+                    "[triage team permissions](https://github.com/orgs/ManageIQ/teams/core-triage)" \
+                    ": jansa/no, jansa/yes"
+
+          expect(issue).to receive(:add_comment).with(message)
+          stub_settings(:member_organization_name => "ManageIQ", :triage_team_name => "my-triage-team")
+        end
+
+        it "only removes the removable applied labels" do
+          expect(issue).to     receive(:remove_label).with("wontfix")
+          expect(issue).not_to receive(:remove_label).with("jansa/no")
+          expect(issue).not_to receive(:remove_label).with("jansa/yes")
+          expect(issue).to     receive(:remove_label).with("jansa/yes?")
+        end
+      end
+
+      context "with a triage user" do
+        let(:triage_members) do
+          [
+            {"login" => "Fryguy"},
+            {"login" => command_issuer}
+          ]
+        end
+
+        before do
+          expect(issue).to receive(:applied_label?).with("jansa/no").and_return(true)
+          expect(issue).to receive(:applied_label?).with("jansa/yes").and_return(true)
+
+          stub_settings(:member_organization_name => "ManageIQ", :triage_team_name => "my-triage-team")
+        end
+
+        it "only removes the applied label" do
+          expect(issue).to receive(:remove_label).with("wontfix")
+          expect(issue).to receive(:remove_label).with("jansa/no")
+          expect(issue).to receive(:remove_label).with("jansa/yes")
+          expect(issue).to receive(:remove_label).with("jansa/yes?")
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,8 @@ RSpec.configure do |config|
     allow_any_instance_of(MinigitService).to receive(:service)
       .and_raise("Live execution is not allowed in specs.  Use stubs/expectations on service instead.")
   end
+
+  config.after { Module.clear_all_cache_with_timeout }
 end
 
 WebMock.disable_net_connect!(:allow_localhost => true)

--- a/spec/support/github_service_helper.rb
+++ b/spec/support/github_service_helper.rb
@@ -1,0 +1,207 @@
+require 'octokit'
+require 'github_service'
+require 'github_service/issue'
+
+module GithubServiceHelper
+  module_function
+
+  # Helper method for configuring the stubs for the GithubService's @service
+  # (Octokit::Client) variable.
+  #
+  # Can be configured in the rspec instance as follows:
+  #
+  #   github_service_stubs do |stub|
+  #     # stub getting issue 1234
+  #     issue_url = '/repos/ManageIQ/manageiq-cross_repo-tests/issues/1234'
+  #     stub.get(issues_url, default_octokit_headers) do |env|
+  #        [200, github_service_response_headers, '{}']
+  #     end
+  #   end
+  #
+  #   # stub creating a new PR on ManageIQ/manageiq-cross_repo-tests
+  #   new_pr_url = '/repos/ManageIQ/manageiq-cross_repo-tests/pulls'
+  #   github_service_stubs.post(new_pr_url, nil, headers) do |env|
+  #      [
+  #        200,                              # response status
+  #        github_service_response_headers,  # response headers
+  #        {                                 # response body
+  #          "id" => 1,
+  #          # ...
+  #        }.to_json
+  #      ]
+  #   end
+  #
+  def github_service_stubs(&block)
+    GithubService.octokit_stubs(&block)
+  end
+
+  # Convenience wrapper method for adding a new Octokit stub.
+  #
+  # Defaults method, headers, requests/response to sensible defaults
+  #
+  # Equivalents to the above examples:
+  #
+  #   issue_url = '/repos/ManageIQ/manageiq-cross_repo-tests/issues/1234'
+  #   github_service_add_stub :url => issue_url
+  #
+  #   new_pr_url = '/repos/ManageIQ/manageiq-cross_repo-tests/pulls'
+  #   github_service_add_stub :url           => issue_url
+  #                           :method        => :post
+  #                           :response_body => {"id" => 1}.to_json
+  #
+  def github_service_add_stub(options = {})
+    url = options[:url] || options[:path]
+    raise "options[:url] is required for github_service_add_stub!" unless url
+
+    request_method   = options[:method]           || :get
+    request_body     = options[:request_body]     || nil
+    request_headers  = options[:request_headers]  || default_octokit_headers
+    response_status  = options[:response_status]  || 200
+    response_body    = options[:response_body]    || "{}"
+    response_headers = options[:response_headers] || github_service_response_headers
+
+    github_service_stubs.send(:new_stub, request_method, url, request_headers, request_body) do
+      [response_status, response_headers, response_body]
+    end
+  end
+
+  # Removes any previous stubs made.
+  #
+  # Useful when overriding a default stub higher up in a rspec context.
+  #
+  # Note: Reaches a bit into the private instance variables on the Faraday
+  # adapter to do this... but it is what is available...
+  #
+  def clear_previous_github_service_stubs!
+    github_service_stubs.instance_variable_set(:@stack, {})
+  end
+
+  # Removes all stubs for a given HTTP method and URL.
+  #
+  # Note: Like the above method, requires the use of the internal API... sorry
+  # not sorry.
+  #
+  def clear_stubs_for!(method, url)
+    stack = github_service_stubs.instance_variable_get(:@stack)
+    return unless stack.key?(method)
+
+    stack[method].delete_if { |stub| stub.path == url }
+  end
+
+  # Enough response data to work with the `GithubService::Issue` object, but
+  # will always be a "Issue", not a Pull Request (since there is no
+  # "pull_request" data returned).
+  #
+  # Based on https://developer.github.com/v3/issues/#get-a-single-issue
+  #
+  def single_issue_request_response(fq_repo_name, issue_id)
+    repository_url = "https://api.github.com/repos/#{fq_repo_name}"
+    {
+      "id"             => issue_id,
+      "url"            => "https://api.github.com/repos/#{fq_repo_name}/issues/#{issue_id}",
+      "number"         => issue_id,
+      "repository_url" => repository_url,
+      "labels"         => [
+        {"name" => "bug"},
+        {"name" => "wip"}
+      ]
+    }.to_json
+  end
+
+  # Enough response data to work with the `GithubService::Issue object
+  #
+  # Based on https://developer.github.com/v3/issues/#get-a-single-issue
+  #
+  def single_pull_request_response(fq_repo_name, pull_request_id)
+    repository_url = "https://api.github.com/repos/#{fq_repo_name}"
+    {
+      "id"             => pull_request_id,
+      "url"            => "https://api.github.com/repos/#{fq_repo_name}/pulls/#{pull_request_id}",
+      "number"         => pull_request_id,
+      "repository_url" => repository_url,
+      "labels"         => [
+        {"name" => "bug"},
+        {"name" => "wip"}
+      ],
+      "pull_request"   => {
+        "url" => "#{repository_url}/pulls/#{pull_request_id}"
+      }
+    }.to_json
+  end
+
+  # Required headers so Sawyer will parse the json properly
+  def github_service_response_headers
+    {"Content-Type" => "application/json"}
+  end
+
+  # Default headers that are configured and sent by Octokit
+  #
+  # The exception here would be 'Accept-Encoding', which is the defaulted in
+  # `net/http`, and is configured in the initializer for
+  # `Net::HTTPGenericRequest`.
+  #
+  # However, since we are using the `Faraday::Adapter::Test` for our
+  # `Octokit::Client`, this is actually not configured here.
+  #
+  def default_octokit_headers
+    {
+      :accept       => ::Octokit::Default.default_media_type,
+      :content_type => "application/json",
+      :user_agent   => ::Octokit::Default.user_agent
+      # :accept_encoding => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+    }
+  end
+end
+
+# Override the `GithubService.service` to use a stub faraday test adapter
+#
+module GithubService
+  class << self
+    # Used by rspec after filter to clear out any previous stubbing
+    #
+    # Can be called manually if necessary to reset the test stubs
+    def unset_service_vars!
+      @service       = nil
+      @octokit_stubs = nil
+    end
+
+    # A Faraday::Adapter::Test::Stubs instance to be used with the "test version"
+    # of the `.service` (Octokit::Client) below
+    #
+    def octokit_stubs(&block)
+      block          ||= proc { |stubs| stubs }
+      @octokit_stubs ||= Faraday::Adapter::Test::Stubs.new(&block)
+    end
+
+    private
+
+    def service
+      @service ||=
+        begin
+          Octokit.configure do |c|
+            # TODO:  Determine if this is needed for specs
+            #
+            # c.login    = Settings.github_credentials.username
+            # c.password = Settings.github_credentials.password
+            c.auto_paginate = true
+
+            c.middleware = Faraday::RackBuilder.new do |builder|
+              builder.use Octokit::Response::RaiseError
+              # builder.response :logger  # uncomment for debugging
+              builder.adapter :test, octokit_stubs
+            end
+          end
+
+          Octokit::Client.new
+        end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include GithubServiceHelper
+
+  config.after do
+    GithubService.unset_service_vars!
+  end
+end


### PR DESCRIPTION
Adds support for the triage team to add any labels.

Adds a concern `IsTeamMember` to handle shared code across `AddLabel` and `RemoveLabel`.

Triage team name is configurable in the settings.

Follow up from #479

**NOTE**:  I am re-using the `github_service_helper.rb` that I introduced in #454 (and also used in #481 as well), and I expect when one of those are merged, I will have to deal with the merge conflicts in the other branches.  It is an isolated commit, so rebasing it should be simple enough.