### PR TITLE
[StaleIssueMarker] Better triage workflow

### DIFF
--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -9,7 +9,7 @@ class StaleIssueMarker
 
   STALE_LABEL_NAME = 'stale'.freeze
   STALE_ISSUE_MESSAGE = <<-EOS.freeze
-This issue has been automatically marked as stale because it has not been updated for at least 6 months.
+This issue has been automatically marked as stale because it has not been updated for at least 3 months.
 
 If you can still reproduce this issue on the current release or on `master`, please reply with all of the information you have about it in order to keep the issue open.
 
@@ -23,6 +23,10 @@ Feel free to reopen this pull request if these changes are still valid.
 Thank you for all your contributions!
   EOS
 
+  # Triage logic:
+  #
+  # - Stale after 3 month of no activity
+  #
   def perform
     GithubService.search_issues(*search_args).each do |issue|
       if issue.pull_request?
@@ -44,7 +48,7 @@ Thank you for all your contributions!
   end
 
   def stale_date
-    @stale_date ||= 6.months.ago
+    @stale_date ||= 3.months.ago
   end
 
   def validate_repo_has_stale_label(repo)

--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -15,7 +15,7 @@ If you can still reproduce this issue on the current release or on `master`, ple
 Thank you for all your contributions!
   EOS
   CLOSABLE_PR_MESSAGE = <<-EOS.freeze
-This pull request has been automatically closed because it has not been updated for at least 6 months.
+This pull request has been automatically closed because it has not been updated for at least 3 months.
 
 Feel free to reopen this pull request if these changes are still valid.
 
@@ -25,6 +25,7 @@ Thank you for all your contributions!
   # Triage logic:
   #
   # - Stale after 3 month of no activity
+  # - Close after stale and inactive for 3 more months
   # - Stale and unmergeable should be closed (assume abandoned, can still be re-opened)
   #
   def perform
@@ -40,7 +41,7 @@ Thank you for all your contributions!
     query << unpinned_query_filter
 
     GithubService.search_issues(query, SEARCH_SORTING).each do |issue|
-      if issue.pull_request?
+      if issue.stale?
         close_pr(issue)
       else
         mark_as_stale(issue)

--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -42,7 +42,7 @@ Thank you for all your contributions!
 
     GithubService.search_issues(query, SEARCH_SORTING).each do |issue|
       if issue.stale?
-        close_pr(issue)
+        comment_and_close(issue)
       else
         mark_as_stale(issue)
       end
@@ -55,7 +55,7 @@ Thank you for all your contributions!
     query << enabled_repos_query_filter
     query << unpinned_query_filter
 
-    GithubService.search_issues(query, SEARCH_SORTING).each { |issue| close_pr(issue) }
+    GithubService.search_issues(query, SEARCH_SORTING).each { |issue| comment_and_close(issue) }
   end
 
   def stale_date
@@ -94,10 +94,10 @@ Thank you for all your contributions!
     issue.add_comment(STALE_ISSUE_MESSAGE)
   end
 
-  def close_pr(pull_request)
-    validate_repo_has_stale_label(pull_request.fq_repo_name)
-    logger.info("[#{Time.now.utc}] - Closing stale PR #{pull_request.fq_repo_name}##{pull_request.number}")
-    GithubService.close_pull_request(pull_request.fq_repo_name, pull_request.number)
-    pull_request.add_comment(CLOSABLE_PR_MESSAGE)
+  def comment_and_close(issue)
+    validate_repo_has_stale_label(issue.fq_repo_name)
+    logger.info("[#{Time.now.utc}] - Closing stale PR #{issue.fq_repo_name}##{issue.number}")
+    GithubService.close_pull_request(issue.fq_repo_name, issue.number)
+    issue.add_comment(CLOSABLE_PR_MESSAGE)
   end
 end

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -73,6 +73,11 @@ module GithubService
       user.login
     end
 
+    # Either "issue" or "pull request"
+    def type
+      pull_request? ? "pull request" : "issue"
+    end
+
     def pull_request?
       respond_to?(:pull_request)
     end

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -81,6 +81,10 @@ module GithubService
       labels.include?(STALE_LABEL)
     end
 
+    def unmergeable?
+      labels.include?(UNMERGEABLE_LABEL)
+    end
+
     # Overrides Octokit response key
     # We manage this ourselves for the life of the issue object to avoid making
     # extra API calls.

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -4,7 +4,9 @@ module GithubService
   class Issue < SimpleDelegator
     # https://developer.github.com/v3/issues
 
-    WIP_REGEX = /^(?:\s*\[wip\])+/i
+    STALE_LABEL       = 'stale'.freeze
+    UNMERGEABLE_LABEL = 'unmergeable'.freeze
+    WIP_REGEX         = /^(?:\s*\[wip\])+/i.freeze
 
     def assign(user)
       GithubService.update_issue(fq_repo_name, number, "assignee" => user)
@@ -73,6 +75,10 @@ module GithubService
 
     def pull_request?
       respond_to?(:pull_request)
+    end
+
+    def stale?
+      labels.include?(STALE_LABEL)
     end
 
     # Overrides Octokit response key

--- a/spec/workers/stale_issue_marker_spec.rb
+++ b/spec/workers/stale_issue_marker_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe StaleIssueMarker do
       end
 
       if [already_stale_issue, stale_and_unmergable_pr, old_unmergable_pr].include?(issue)
-        expect(issue).to receive(:add_comment).with(/This pull request.*closed/)
+        expect(issue).to receive(:add_comment).with(/This (pull request|issue).*closed/)
         expect(GithubService).to receive(:close_pull_request).with(fq_repo_name, issue.number)
       else
-        expect(issue).to receive(:add_comment).with(/This issue.*marked as stale/)
+        expect(issue).to receive(:add_comment).with(/This (pull request|issue).*marked as stale/)
         expect(GithubService).to_not receive(:close_pull_request).with(issue.number)
       end
     end

--- a/spec/workers/stale_issue_marker_spec.rb
+++ b/spec/workers/stale_issue_marker_spec.rb
@@ -32,15 +32,28 @@ RSpec.describe StaleIssueMarker do
            :labels        => [])
   end
 
+  let(:stale_and_unmergable_pr) do
+    double("stale_and_unmergable_pr",
+           :updated_at    => 4.months.ago,
+           :fq_repo_name  => fq_repo_name,
+           :number        => 9001,
+           :pull_request? => true,
+           :labels        => ["stale", "unmergeable"])
+  end
+
   let(:issues) do
     [already_stale_issue,
      stale_issue,
      stale_pr]
   end
 
-  let(:update_filter) { "update:<#{stale_date.strftime('%Y-%m-%d')}" }
-  let(:repo_filter)   { %(repo:"#{fq_repo_name}") }
-  let(:search_query)  { %(is:open archived:false #{update_filter} -label:"pinned" #{repo_filter}) }
+  let(:search_query)      { "#{issue_filter} #{update_filter} #{repo_filter} #{pinned_filter}" }
+  let(:unmergeable_query) { "#{issue_filter} is:pr #{labels_filter} #{repo_filter} #{pinned_filter}" }
+  let(:issue_filter)      { "is:open archived:false" }
+  let(:update_filter)     { "update:<#{stale_date.strftime('%Y-%m-%d')}" }
+  let(:repo_filter)       { %(repo:"#{fq_repo_name}") }
+  let(:pinned_filter)     { %(-label:"pinned") }
+  let(:labels_filter)     { %(label:"stale" label:"unmergeable") }
 
   before do
     allow(described_class).to receive(:enabled_repo_names).and_return([fq_repo_name])
@@ -48,6 +61,9 @@ RSpec.describe StaleIssueMarker do
     allow(GithubService).to receive(:search_issues)
       .with(search_query, :sort => :updated, :direction => :asc)
       .and_return(issues)
+    allow(GithubService).to receive(:search_issues)
+      .with(unmergeable_query, :sort => :updated, :direction => :asc)
+      .and_return([stale_and_unmergable_pr])
     allow(GithubService).to receive(:valid_label?).with(fq_repo_name, "stale").and_return(true)
     allow(Sidekiq).to receive(:logger).and_return(double(:info => nil))
   end
@@ -61,7 +77,9 @@ RSpec.describe StaleIssueMarker do
     expect(stale_issue).to receive(:add_comment).with(/This issue.*marked as stale/)
 
     expect(GithubService).to receive(:close_pull_request).with(fq_repo_name, stale_pr.number)
+    expect(GithubService).to receive(:close_pull_request).with(fq_repo_name, stale_and_unmergable_pr.number)
     expect(stale_pr).to receive(:add_comment).with(/This pull request.*closed/)
+    expect(stale_and_unmergable_pr).to receive(:add_comment).with(/This pull request.*closed/)
 
     issues.each do |issue|
       unless issue == stale_issue
@@ -70,7 +88,7 @@ RSpec.describe StaleIssueMarker do
     end
 
     issues.each do |issue|
-      unless issue == stale_pr
+      unless [stale_pr, stale_and_unmergable_pr].include?(issue)
         expect(GithubService).to_not receive(:close_pull_request).with(issue.number)
       end
     end

--- a/spec/workers/stale_issue_marker_spec.rb
+++ b/spec/workers/stale_issue_marker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe StaleIssueMarker do
 
   let(:already_stale_issue) do
     double("already_stale_issue",
-           :updated_at    => 8.months.ago,
+           :updated_at    => 6.months.ago,
            :fq_repo_name  => fq_repo_name,
            :number        => 3,
            :pull_request? => false,
@@ -16,7 +16,7 @@ RSpec.describe StaleIssueMarker do
 
   let(:stale_issue) do
     double("stale_issue",
-           :updated_at    => 7.months.ago,
+           :updated_at    => 5.months.ago,
            :fq_repo_name  => fq_repo_name,
            :number        => 4,
            :pull_request? => false,
@@ -25,7 +25,7 @@ RSpec.describe StaleIssueMarker do
 
   let(:stale_pr) do
     double("stale_pr",
-           :updated_at    => 7.months.ago,
+           :updated_at    => 4.months.ago,
            :fq_repo_name  => fq_repo_name,
            :number        => 2,
            :pull_request? => true,

--- a/spec/workers/stale_issue_marker_spec.rb
+++ b/spec/workers/stale_issue_marker_spec.rb
@@ -1,44 +1,52 @@
 require "spec_helper"
 
 RSpec.describe StaleIssueMarker do
+  def create_stub_issue(name, data)
+    agent = GithubService.send(:service).agent
+    GithubService::Issue.new(Sawyer::Resource.new(agent, {:name => name}.merge(data)))
+  end
+
+  def labels(label_names)
+    label_names.map { |n| {:name => n} }
+  end
+
   let(:subject)      { described_class.new }
   let(:stale_date)   { 6.months.ago }
+  let(:repo_url)     { "https://api.github.com/repos/#{fq_repo_name}" }
   let(:fq_repo_name) { "foo/bar" }
 
   let(:already_stale_issue) do
-    double("already_stale_issue",
-           :updated_at    => 6.months.ago,
-           :fq_repo_name  => fq_repo_name,
-           :number        => 3,
-           :pull_request? => false,
-           :labels        => %w(stale bug))
+    create_stub_issue("already_stale_issue",
+                      :updated_at     => 6.months.ago,
+                      :repository_url => repo_url,
+                      :number         => 3,
+                      :labels         => labels(%w[stale bug]))
   end
 
   let(:stale_issue) do
-    double("stale_issue",
-           :updated_at    => 5.months.ago,
-           :fq_repo_name  => fq_repo_name,
-           :number        => 4,
-           :pull_request? => false,
-           :labels        => ["bug"])
+    create_stub_issue("stale_issue",
+                      :updated_at     => 5.months.ago,
+                      :repository_url => repo_url,
+                      :number         => 4,
+                      :labels         => labels(["bug"]))
   end
 
   let(:stale_pr) do
-    double("stale_pr",
-           :updated_at    => 4.months.ago,
-           :fq_repo_name  => fq_repo_name,
-           :number        => 2,
-           :pull_request? => true,
-           :labels        => [])
+    create_stub_issue("stale_pr",
+                      :updated_at     => 4.months.ago,
+                      :repository_url => repo_url,
+                      :number         => 2,
+                      :pull_request   => true,
+                      :labels         => [])
   end
 
   let(:stale_and_unmergable_pr) do
-    double("stale_and_unmergable_pr",
-           :updated_at    => 4.months.ago,
-           :fq_repo_name  => fq_repo_name,
-           :number        => 9001,
-           :pull_request? => true,
-           :labels        => ["stale", "unmergeable"])
+    create_stub_issue("stale_and_unmergable_pr",
+                      :updated_at     => 4.months.ago,
+                      :repository_url => repo_url,
+                      :number         => 9001,
+                      :pull_request   => true,
+                      :labels         => labels(["stale", "unmergeable"]))
   end
 
   let(:issues) do


### PR DESCRIPTION
There are a lot of changes here, and the commits go into greater detail, but at a high level:

- Bumps marking as `stale` to 3 months
- Auto closes pull requests that are `stale` and `unmergeable`
- Handles Pull Requests and Issues in the same manner
- When a `verified` issue becomes `stale`, remove `verified` and mark as `requires triage`
- Misc refactorings and changes to support the above


Notes
-----

- The `requires triage` label was just a label name I picked, but can be changed to whatever
  - (when the label name is decided on, that will need to be set for all repos)
- Some code was moved around to be put in `GithubService::Issue` instead of in this class.  Mostly for readability, but I could see how it might be considered a controversial change.
- The copy for marking stale and closing stale could probably use some review.
- `RSpec` `doubles` became a bit of a pain to manage in the specs, so I switch them to `GithubService::Issue` objects with valid `Sawyer::Resource` objects under the hood.  There is a little more "under the covers" knowledge about `Octokit` that is required for this, but it avoids some over stubbing that would have had to be done as a result of some of the refactoring.  I could see this also being a bit of a controversial change.
- This probably could be broken into the subcomponents described previously ( https://github.com/ManageIQ/miq_bot/issues/390#issuecomment-577715811 ), but was easier to think about this problem all at once instead of trying to address in tiny pieces.  That said, if requested I can break this up into the individual RFE items with little effort, but will leave that up to the reviewers.


Also, there is still a very big question mark around the "nudging" concept that was requested as part of #390 that I am unsure how to tackle still.


### The "bump" feature problem

The main concern here is that once the bot introduces a comment, it actually updates the `updated_at` field, and changes the search criteria pretty considerably.

To illustrate, right now we make two searches:

- All non-pinned issues/PRs that are becoming `stale`, or have been stale now for 3 months
- Any PRs that are now `stale` and `unmergeable`

The first of the above actually takes care of two of our use cases, since they both share the 3 months time window for `updated_at`, and whenever a bot interacts with a issue/PR, it resets that timer.  As a result with it, we also don't have to filter based on the `stale` label in the query, and just handle what we do with the issues that we get back from the search.


If we implement the "nudging/bump" concept, we would then get a set of search queries that look something like this:

- Un-pinned issues/PRs that have been untouched for 1 month, less than 2 months, and aren't `stale` (handle nudging)
- Un-pinned issues/PRs that have been untouched for 2 months, and aren't `stale`    (handle newly stale)
- `stale` issues/PRs that have been untouched for 3 months`                      (handle old and stale)
- Any PRs that are now `stale` and `unmergeable`                                 (handle newly unmergeable stale PRs)

Doubles our number of queries, but more importantly, it makes the whole process a bit harder to wrap my head around, and I am sure it would be harder for others as well.  Feels like there is little gain to be had for a decent amount of a logic change, but am unsure what of #390 is considered more important at this point.

Will leave the decision of pursuing the "bump" feature further to reviewers/assignies.


Links
-----

- Fixes #390 (original RFE)
- Fixes #433
- Fixes #437