### PR TITLE
Fix CreateBatchTables migration

### DIFF
--- a/db/migrate/20140115031432_create_commit_monitor_repos.rb
+++ b/db/migrate/20140115031432_create_commit_monitor_repos.rb
@@ -1,4 +1,4 @@
-class CreateCommitMonitorRepos < ActiveRecord::Migration[5.1]
+class CreateCommitMonitorRepos < ActiveRecord::Migration[4.2]
   def change
     create_table :commit_monitor_repos do |t|
       t.string :name

--- a/db/migrate/20140116232751_create_commit_monitor_branches.rb
+++ b/db/migrate/20140116232751_create_commit_monitor_branches.rb
@@ -1,4 +1,4 @@
-class CreateCommitMonitorBranches < ActiveRecord::Migration[5.1]
+class CreateCommitMonitorBranches < ActiveRecord::Migration[4.2]
   def change
     create_table :commit_monitor_branches do |t|
       t.string :name

--- a/db/migrate/20140117055336_add_pull_request_to_commit_monitor_branch.rb
+++ b/db/migrate/20140117055336_add_pull_request_to_commit_monitor_branch.rb
@@ -1,4 +1,4 @@
-class AddPullRequestToCommitMonitorBranch < ActiveRecord::Migration[5.1]
+class AddPullRequestToCommitMonitorBranch < ActiveRecord::Migration[4.2]
   def change
     add_column :commit_monitor_branches, :pull_request, :boolean
   end

--- a/db/migrate/20140117063400_add_upstream_user_to_commit_monitor_repo.rb
+++ b/db/migrate/20140117063400_add_upstream_user_to_commit_monitor_repo.rb
@@ -1,4 +1,4 @@
-class AddUpstreamUserToCommitMonitorRepo < ActiveRecord::Migration[5.1]
+class AddUpstreamUserToCommitMonitorRepo < ActiveRecord::Migration[4.2]
   def change
     add_column :commit_monitor_repos, :upstream_user, :string
   end

--- a/db/migrate/20140128174930_replace_timestamps_with_last_checked_on_and_last_changed_on_for_commit_monitor_branches.rb
+++ b/db/migrate/20140128174930_replace_timestamps_with_last_checked_on_and_last_changed_on_for_commit_monitor_branches.rb
@@ -1,4 +1,4 @@
-class ReplaceTimestampsWithLastCheckedOnAndLastChangedOnForCommitMonitorBranches < ActiveRecord::Migration[5.1]
+class ReplaceTimestampsWithLastCheckedOnAndLastChangedOnForCommitMonitorBranches < ActiveRecord::Migration[4.2]
   class CommitMonitorBranch < ActiveRecord::Base
   end
 

--- a/db/migrate/20140214211340_add_commits_list_to_commit_monitor_branches.rb
+++ b/db/migrate/20140214211340_add_commits_list_to_commit_monitor_branches.rb
@@ -1,4 +1,4 @@
-class AddCommitsListToCommitMonitorBranches < ActiveRecord::Migration[5.1]
+class AddCommitsListToCommitMonitorBranches < ActiveRecord::Migration[4.2]
   def change
     add_column :commit_monitor_branches, :commits_list, :text
   end

--- a/db/migrate/20140215060546_add_mergeable_to_commit_monitor_branch.rb
+++ b/db/migrate/20140215060546_add_mergeable_to_commit_monitor_branch.rb
@@ -1,4 +1,4 @@
-class AddMergeableToCommitMonitorBranch < ActiveRecord::Migration[5.1]
+class AddMergeableToCommitMonitorBranch < ActiveRecord::Migration[4.2]
   def change
     add_column :commit_monitor_branches, :mergeable, :boolean
   end

--- a/db/migrate/20150730043503_create_batch_tables.rb
+++ b/db/migrate/20150730043503_create_batch_tables.rb
@@ -1,4 +1,4 @@
-class CreateBatchTables < ActiveRecord::Migration[5.1]
+class CreateBatchTables < ActiveRecord::Migration[4.2]
   def change
     create_table :batch_jobs do |t|
       t.timestamps

--- a/db/migrate/20150806034945_add_on_complete_class_and_args_to_batch_jobs.rb
+++ b/db/migrate/20150806034945_add_on_complete_class_and_args_to_batch_jobs.rb
@@ -1,4 +1,4 @@
-class AddOnCompleteClassAndArgsToBatchJobs < ActiveRecord::Migration[5.1]
+class AddOnCompleteClassAndArgsToBatchJobs < ActiveRecord::Migration[4.2]
   def change
     add_column :batch_jobs, :on_complete_class, :string
     add_column :batch_jobs, :on_complete_args, :text

--- a/db/migrate/20150814183817_rename_commit_monitor_repos_to_repos.rb
+++ b/db/migrate/20150814183817_rename_commit_monitor_repos_to_repos.rb
@@ -1,4 +1,4 @@
-class RenameCommitMonitorReposToRepos < ActiveRecord::Migration[5.1]
+class RenameCommitMonitorReposToRepos < ActiveRecord::Migration[4.2]
   def change
     rename_table :commit_monitor_repos, :repos
   end

--- a/db/migrate/20150814183834_rename_commit_monitor_branches_to_branches.rb
+++ b/db/migrate/20150814183834_rename_commit_monitor_branches_to_branches.rb
@@ -1,4 +1,4 @@
-class RenameCommitMonitorBranchesToBranches < ActiveRecord::Migration[5.1]
+class RenameCommitMonitorBranchesToBranches < ActiveRecord::Migration[4.2]
   def change
     rename_table :commit_monitor_branches, :branches
   end

--- a/db/migrate/20150814191457_rename_branches_foreign_key.rb
+++ b/db/migrate/20150814191457_rename_branches_foreign_key.rb
@@ -1,4 +1,4 @@
-class RenameBranchesForeignKey < ActiveRecord::Migration[5.1]
+class RenameBranchesForeignKey < ActiveRecord::Migration[4.2]
   def change
     rename_column :branches, :commit_monitor_repo_id, :repo_id
   end

--- a/db/migrate/20150814233450_add_state_to_batch_jobs.rb
+++ b/db/migrate/20150814233450_add_state_to_batch_jobs.rb
@@ -1,4 +1,4 @@
-class AddStateToBatchJobs < ActiveRecord::Migration[5.1]
+class AddStateToBatchJobs < ActiveRecord::Migration[4.2]
   def change
     add_column :batch_jobs, :state, :string
   end

--- a/db/migrate/20150827194533_collapse_repo_upstream_user_into_name.rb
+++ b/db/migrate/20150827194533_collapse_repo_upstream_user_into_name.rb
@@ -1,4 +1,4 @@
-class CollapseRepoUpstreamUserIntoName < ActiveRecord::Migration[5.1]
+class CollapseRepoUpstreamUserIntoName < ActiveRecord::Migration[4.2]
   class Repo < ActiveRecord::Base
   end
 

--- a/db/migrate/20151204171252_update_branch_name_for_pr_branches.rb
+++ b/db/migrate/20151204171252_update_branch_name_for_pr_branches.rb
@@ -1,4 +1,4 @@
-class UpdateBranchNameForPrBranches < ActiveRecord::Migration[5.1]
+class UpdateBranchNameForPrBranches < ActiveRecord::Migration[4.2]
   class Branch < ActiveRecord::Base; end # Don't use the real model
 
   def up

--- a/db/migrate/20151207193108_remove_path_from_repo.rb
+++ b/db/migrate/20151207193108_remove_path_from_repo.rb
@@ -1,4 +1,4 @@
-class RemovePathFromRepo < ActiveRecord::Migration[5.1]
+class RemovePathFromRepo < ActiveRecord::Migration[4.2]
   def change
     remove_column :repos, :path, :string
   end

--- a/db/migrate/20160119143158_add_merge_head_to_branch.rb
+++ b/db/migrate/20160119143158_add_merge_head_to_branch.rb
@@ -1,4 +1,4 @@
-class AddMergeHeadToBranch < ActiveRecord::Migration[5.1]
+class AddMergeHeadToBranch < ActiveRecord::Migration[4.2]
   class Branch < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20160713200646_add_pr_title_to_branch.rb
+++ b/db/migrate/20160713200646_add_pr_title_to_branch.rb
@@ -1,4 +1,4 @@
-class AddPrTitleToBranch < ActiveRecord::Migration[5.1]
+class AddPrTitleToBranch < ActiveRecord::Migration[4.2]
   def change
     add_column :branches, :pr_title, :string
   end

--- a/db/migrate/20170127173128_fix_limit_in_schema.rb
+++ b/db/migrate/20170127173128_fix_limit_in_schema.rb
@@ -1,4 +1,4 @@
-class FixLimitInSchema < ActiveRecord::Migration[5.1]
+class FixLimitInSchema < ActiveRecord::Migration[4.2]
   def up
     change_column :batch_entries, :state, :string, :limit => 255
     change_column :batch_jobs, :on_complete_class, :string, :limit => 255

--- a/db/migrate/20171006050814_add_linter_offense_count_to_branch.rb
+++ b/db/migrate/20171006050814_add_linter_offense_count_to_branch.rb
@@ -1,4 +1,4 @@
-class AddLinterOffenseCountToBranch < ActiveRecord::Migration[5.1]
+class AddLinterOffenseCountToBranch < ActiveRecord::Migration[4.2]
   def change
     add_column :branches, :linter_offense_count, :integer
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,27 +15,27 @@ ActiveRecord::Schema.define(version: 2017_10_06_050814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "batch_entries", force: :cascade do |t|
-    t.bigint "batch_job_id"
+  create_table "batch_entries", id: :serial, force: :cascade do |t|
+    t.integer "batch_job_id"
     t.string "state", limit: 255
     t.text "result"
     t.index ["batch_job_id"], name: "index_batch_entries_on_batch_job_id"
   end
 
-  create_table "batch_jobs", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "batch_jobs", id: :serial, force: :cascade do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "expires_at"
     t.string "on_complete_class", limit: 255
     t.text "on_complete_args"
     t.string "state", limit: 255
   end
 
-  create_table "branches", force: :cascade do |t|
+  create_table "branches", id: :serial, force: :cascade do |t|
     t.string "name", limit: 255
     t.string "commit_uri", limit: 255
     t.string "last_commit", limit: 255
-    t.bigint "repo_id"
+    t.integer "repo_id"
     t.boolean "pull_request"
     t.datetime "last_checked_on"
     t.datetime "last_changed_on"
@@ -44,13 +44,12 @@ ActiveRecord::Schema.define(version: 2017_10_06_050814) do
     t.string "merge_target"
     t.string "pr_title"
     t.integer "linter_offense_count"
-    t.index ["repo_id"], name: "index_branches_on_repo_id"
   end
 
-  create_table "repos", force: :cascade do |t|
+  create_table "repos", id: :serial, force: :cascade do |t|
     t.string "name", limit: 255
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end


### PR DESCRIPTION
Use 4.2 for all of the migrations, since they were all done prior to the upgrade from 4.2 -> 5.2 and '4.2' is the lowest possible value available:

```
ArgumentError:  Unknown migration version "4.0"; expected one of "4.2", "5.0", "5.1", "5.2"
```

'4.2' is the closest option that makes sense.


Links
-----

- Rails 5.2 upgrade PR:  https://github.com/ManageIQ/miq_bot/pull/466


Testing
-------

This doesn't seem to be show via CI since it probably (too lazy to check) does a `rake db:schema:load`, so doing the following:

```console
$ RAILS_ENV=development bundle exec rake db:environment:set db:drop db:create db:migrate
```

Should work with this patch in place.


Fixes #489