### PR TITLE
[CommitMetadataChecker] Ignore emails

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker.rb
@@ -32,9 +32,11 @@ module CommitMonitorHandlers::CommitRange
     #     "Username may only contain alphanumeric characters or single hyphens,
     #     and cannot begin or end with a hyphen."
     #
-    # For the beginning and and, we do a positive lookbehind at the beginning
-    # to get the `@`, and a positive lookhead at the end to confirm their is
-    # either a period or a whitespace following the "var" (instance_variable)
+    # To check for the start of a username we do a positive lookbehind to get
+    # the `@` (but only if it is surrounded by whitespace), and a positive
+    # lookhead at the end to confirm there is a whitespace char following the
+    # "var" (isn't an instance variable with a trailing `.`, has an `_`, or is
+    # actually an email address)
     #
     # Since there can't be underscores in Github usernames, this makes it so we
     # rule out partial matches of variables (@database_records having a

--- a/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker.rb
@@ -42,11 +42,11 @@ module CommitMonitorHandlers::CommitRange
     # without underscores (`@foobarbaz`).
     #
     USERNAME_REGEXP = /
-      (?<=@)          # must start with a '@' (don't capture)
+      (?<=^@|\s@)     # must start with a '@' (don't capture)
       [a-zA-Z0-9]     # first character must be alphanumeric
       [a-zA-Z0-9\-]*  # middle chars may be alphanumeric or hyphens
       [a-zA-Z0-9]     # last character must be alphanumeric
-      (?=[\.\s])      # allow only variables without "_" (not captured)
+      (?=[\s])        # allow only variables without "_" (not captured)
     /x.freeze
 
     def check_for_usernames_in(commit, message)

--- a/spec/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker_spec.rb
@@ -47,6 +47,7 @@ describe CommitMonitorHandlers::CommitRange::GithubPrCommenter::CommitMetadataCh
         With this change, I made it so that by changing this:
 
             @database_records = Books.all
+            @database_records.to_a
 
         Avoids a N+1 on authors by adding an .includes call
 
@@ -58,11 +59,17 @@ describe CommitMonitorHandlers::CommitRange::GithubPrCommenter::CommitMetadataCh
       COMMIT_MSG
     end
 
+    # Note:  `@dbrecords` in this message are all cases that will not get
+    # picked up as a username in this example.
     let(:commit_message_2) do
       <<~COMMIT_MSG
         fixes tests
 
         Forgot that we stubbed things...
+
+        `expect(@dbrecords).to ...` not `any_instance_of(ActiveRecord).to ...`
+
+        Assign it as a variable by doing `@dbrecords = %w[foo bar]`
 
         cc @Fryguy @NickLaMuro
       COMMIT_MSG
@@ -73,6 +80,8 @@ describe CommitMonitorHandlers::CommitRange::GithubPrCommenter::CommitMetadataCh
         fixes moar tests
 
         I forget how to rebase... #dealWithIt @NickLaMura
+
+        Original commit by nicklamuro@example.com
       COMMIT_MSG
     end
 


### PR DESCRIPTION
Includes better handling of variables to avoid the following better:

- Check if the `@` is preceded by whitespace or a new line (valid user)
- Don't allow trailing periods (not a user)

The trailing periods was a mistake, and was meant to be the inverse where things like this:

- `@user.name`
- `foo@example.com`

so those wouldn't get flagged by the bot.  Some examples in the specs were updated to address this cases better.

Address issue brought up in `gitter`:  https://gitter.im/ManageIQ/miq_bot?at=5e83b90b57d801084bd4935a


Example "bad" output:
---------------------

> `060b7af`
> 
> - [ ] :grey_exclamation: - Username `@redhat` detected in commit message. Consider removing.
> - [ ] :grey_exclamation: - Username `@redhat` detected in commit message. Consider removing.
> 
> `17137a6`
> 
> - [ ] :grey_exclamation: - Username `@redhat` detected in commit message. Consider removing.
> - [ ] :grey_exclamation: - Username `@redhat` detected in commit message. Consider removing.
> 
> `21eae4d`
> 
> - [ ] :grey_exclamation: - Username `@redhat` detected in commit message. Consider removing.
> - [ ] :grey_exclamation: - Username `@redhat` detected in commit message. Consider removing.
> 
> ...


Links
-----

- Original feature:  https://github.com/ManageIQ/miq_bot/pull/481
- Issue from `gitter`: [link](https://gitter.im/ManageIQ/miq_bot?at=5e83b90b57d801084bd4935a)
- `git_commit.full_message`:
  - https://github.com/ManageIQ/miq_bot/blob/fdf4c825/app/workers/commit_monitor.rb#L115-L124
  - https://github.com/ManageIQ/miq_bot/blob/fdf4c825/lib/git_service/commit.rb#L26-L41