### PR TITLE
[CommitMonitor] Send commit .details_hash instead of .full_message

### DIFF
--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -115,11 +115,7 @@ class CommitMonitor
   def new_commits_details
     @new_commits_details ||=
       new_commits.each_with_object({}) do |commit, h|
-        git_commit = branch.git_service.commit(commit)
-        h[commit] = {
-          "message" => git_commit.full_message,
-          "files"   => git_commit.diff.file_status.keys
-        }
+        h[commit] = branch.git_service.commit(commit).details_hash
       end
   end
 

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -70,5 +70,21 @@ module GitService
       message << "\n #{diff.status_summary}"
       message
     end
+
+    def details_hash
+      {
+        "sha"            => commit_oid,
+        "parent_oids"    => parent_oids,
+        "merge_commit?"  => parent_oids.length > 1,
+        "author"         => formatted_author,
+        "author_date"    => formatted_author_date,
+        "commit"         => formatted_committer,
+        "commit_date"    => formatted_committer_date,
+        "message"        => formatted_commit_message,
+        "files"          => diff.file_status.keys,
+        "stats"          => formatted_commit_stats,
+        "status_summary" => diff.status_summary
+      }
+    end
   end
 end

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -23,13 +23,21 @@ module GitService
       other_commit.diff(rugged_commit)
     end
 
+    def formatted_author
+      "#{rugged_commit.author[:name]} <#{rugged_commit.author[:email]}>"
+    end
+
+    def formatted_author_date
+      rugged_commit.author[:time].to_time.strftime("%c %z")
+    end
+
     def full_message
       message = "commit #{commit_oid}\n"
       message << "Merge: #{parent_oids.join(" ")}\n" if parent_oids.length > 1
-      message << "Author:     #{rugged_commit.author[:name]} <#{rugged_commit.author[:email]}>\n"
-      message << "AuthorDate: #{rugged_commit.author[:time].to_time.strftime("%c %z")}\n"
-      message << "Commit:     #{rugged_commit.author[:name]} <#{rugged_commit.author[:email]}>\n"
-      message << "CommitDate: #{rugged_commit.author[:time].to_time.strftime("%c %z")}\n"
+      message << "Author:     #{formatted_author}\n"
+      message << "AuthorDate: #{formatted_author_date}\n"
+      message << "Commit:     #{formatted_author}\n"
+      message << "CommitDate: #{formatted_author_date}\n"
       message << "\n"
       message << rugged_commit.message.indent(4)
       message << "\n"

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -39,6 +39,11 @@ module GitService
       rugged_commit.committer[:time].to_time.strftime("%c %z")
     end
 
+    # Note:  really not needed, but keeps it consistent
+    def formatted_commit_message
+      rugged_commit.message
+    end
+
     def formatted_commit_stats
       diff.file_status.map do |file, stats|
         file_stats  = file.dup
@@ -59,7 +64,7 @@ module GitService
       message << "Commit:     #{formatted_committer}\n"
       message << "CommitDate: #{formatted_committer_date}\n"
       message << "\n"
-      message << rugged_commit.message.indent(4)
+      message << formatted_commit_message.indent(4)
       message << "\n"
       message << formatted_commit_stats.join("\n").indent(1)
       message << "\n #{diff.status_summary}"

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -31,13 +31,21 @@ module GitService
       rugged_commit.author[:time].to_time.strftime("%c %z")
     end
 
+    def formatted_committer
+      "#{rugged_commit.committer[:name]} <#{rugged_commit.committer[:email]}>"
+    end
+
+    def formatted_committer_date
+      rugged_commit.committer[:time].to_time.strftime("%c %z")
+    end
+
     def full_message
       message = "commit #{commit_oid}\n"
       message << "Merge: #{parent_oids.join(" ")}\n" if parent_oids.length > 1
       message << "Author:     #{formatted_author}\n"
       message << "AuthorDate: #{formatted_author_date}\n"
-      message << "Commit:     #{formatted_author}\n"
-      message << "CommitDate: #{formatted_author_date}\n"
+      message << "Commit:     #{formatted_committer}\n"
+      message << "CommitDate: #{formatted_committer_date}\n"
       message << "\n"
       message << rugged_commit.message.indent(4)
       message << "\n"

--- a/lib/git_service/commit.rb
+++ b/lib/git_service/commit.rb
@@ -39,6 +39,18 @@ module GitService
       rugged_commit.committer[:time].to_time.strftime("%c %z")
     end
 
+    def formatted_commit_stats
+      diff.file_status.map do |file, stats|
+        file_stats  = file.dup
+        file_stats << " | "
+        file_stats << (stats[:additions].to_i + stats[:deletions].to_i).to_s
+        file_stats << " "
+        file_stats << "+" if stats[:additions].positive?
+        file_stats << "-" if stats[:deletions].positive?
+        file_stats
+      end
+    end
+
     def full_message
       message = "commit #{commit_oid}\n"
       message << "Merge: #{parent_oids.join(" ")}\n" if parent_oids.length > 1
@@ -49,10 +61,8 @@ module GitService
       message << "\n"
       message << rugged_commit.message.indent(4)
       message << "\n"
-      diff.file_status.each do |file, stats|
-        message << " #{file} | #{stats[:additions].to_i + stats[:deletions].to_i} #{"+" if stats[:additions].positive?}#{"-" if stats[:deletions].positive?}\n"
-      end
-      message << " #{diff.status_summary}"
+      message << formatted_commit_stats.join("\n").indent(1)
+      message << "\n #{diff.status_summary}"
       message
     end
   end


### PR DESCRIPTION
This is a followup to the changes from https://github.com/ManageIQ/miq_bot/pull/493 which ensure that we are only parsing the commit "message", and not the contents of the committer email, author email, etc.

A bit of a discussion on this can be found here:

https://gitter.im/ManageIQ/miq_bot?at=5e83d09b74c36c7bc678ff13

The PR itself is mostly a exercising in refactoring, and currently only the last two commits changes anything for the `CommitMonitor` and nested handler workers from that.


Notes on Usage of `new_commits_details`
---------------------------------------

It was brought up as a concern (by myself), that `new_commits_details` is potentially used by other handlers.  This is not the case, so this change is safe to make, but for background:

The two other `pull_request_monitor_handlers/` besides `CommitMetadataChecker`:

- `DiffContentChecker`:
  https://github.com/ManageIQ/miq_bot/blob/2a2ab16b3c094c3b65242cbee337172bbbf41834/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/diff_content_checker.rb#L11
- `DiffFilenameChecker`:
  https://github.com/ManageIQ/miq_bot/blob/master/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/diff_filename_checker.rb#L11

Both ignore `_new_commits_details`.

In addition, their are only two `CommitMonitor` handler groups that make use of `new_commits_details`:

- "commit" handlers (which there are none):
  https://github.com/ManageIQ/miq_bot/blob/9595dd1064ace4eef1ce835481b6a8b0af44e4d4/app/workers/commit_monitor.rb#L201-L208
- "batch" handlers (which only includes `GithubPrCommenter`)
  https://github.com/ManageIQ/miq_bot/blob/9595dd1064ace4eef1ce835481b6a8b0af44e4d4/app/workers/commit_monitor.rb#L226-L231

So it should be safe to make this change and no other class should miss it.