### PR TITLE
Remove therubyracer gem as it's not used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,6 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .js.coffee assets and views
 gem 'coffee-rails', '~> 4.2.2'
 
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer', :platforms => :ruby
-
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,6 @@ GEM
     json (2.3.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.19)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -267,7 +266,6 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.3)
-    ref (2.0.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -347,9 +345,6 @@ GEM
       sprockets (>= 3.0.0)
     sysexits (1.2.0)
     temple (0.8.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -438,7 +433,6 @@ DEPENDENCIES
   sidetiq (~> 0.7.0)
   sinatra
   slim
-  therubyracer
   thin
   timecop
   tracker_api (~> 1.6)


### PR DESCRIPTION
I tested this locally via `rails s`, and ran the tests with `rake`.  I'm not sure what else can prove whether we used it or not?

My main motivation is I can't seem to build libv8 at all in either Ruby 2.5 or 2.6, and if we don't need it, why not kill it?

@NickLaMuro @bdunne Please review.