### PR TITLE
Add db/seeds.local.rb support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 # Ignore local repos folder
 /repos
 
+# Ignore local seeds file
+db/seeds.local.rb

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+require_relative 'seeds.local.rb' if File.exist?(File.expand_path('seeds.local.rb', __dir__))


### PR DESCRIPTION
Allows for specifying a local file for seeding a database based on custom records.

Since development for this repository requires user specific repos to be created for testing, this can allow a DB reset less painfully.


**Note**:  This is also just me cleaning up some local changes I had that I figured might be worth sharing.  Feel free to close if you don't think it is useful.