### PR TITLE
GitHub Status API Integration (rebased)

### DIFF
--- a/spec/lib/github_service_spec.rb
+++ b/spec/lib/github_service_spec.rb
@@ -1,4 +1,9 @@
 describe GithubService do
+  let(:repo) { "owner/repository" }
+  let(:sha) { "b0e6911a4b7cc8dcf6aa4ed28244a1d5fb90d051" }
+  let(:url) { "https://github.com/" }
+  let(:num) { 42 }
+
   describe "#username_lookup" do
     let(:lookup_username) { "NickLaMuro" }
     let(:lookup_status)   { 200 }
@@ -58,6 +63,59 @@ describe GithubService do
         end.to raise_error(RuntimeError, "Error on GitHub with username lookup")
         expect(lookup_cache).to eq({})
       end
+    end
+  end
+
+  describe ".add_status" do
+    let(:username) { "name" }
+
+    before do
+      stub_settings(Hash(:github_credentials => {:username => username}))
+    end
+
+    it "should create a success state (zero offenses)" do
+      expect(described_class).to receive(:create_status).with(repo, sha, "success", Hash("context" => username, "target_url" => url, "description" => "Everything looks fine."))
+
+      described_class.add_status(repo, sha, url, :zero)
+    end
+
+    it "should create an success state (some offenses)" do
+      expect(described_class).to receive(:create_status).with(repo, sha, "success", Hash("context" => username, "target_url" => url, "description" => "Some offenses detected."))
+
+      described_class.add_status(repo, sha, url, :warn)
+    end
+
+    it "should create an error state (at least one bomb offense)" do
+      expect(described_class).to receive(:create_status).with(repo, sha, "error", Hash("context" => username, "target_url" => url, "description" => "Something went wrong."))
+
+      described_class.add_status(repo, sha, url, :bomb)
+    end
+  end
+
+  describe ".add_comments" do
+    let(:comment_in) { "input_comment" }
+    let(:comments_in) { [comment_in, comment_in, comment_in] }
+    let(:comment_out) { Hash("html_url"=> url) }
+
+    it "should return an array of comments" do
+      expect(described_class).to receive(:add_comment).with(repo, num, comment_in).and_return(comment_out).exactly(comments_in.count)
+      expect(described_class.add_comments(repo, num, comments_in)).to match_array([comment_out, comment_out, comment_out])
+    end
+  end
+
+  describe ".replace_comments" do
+    let(:comments_in) { %w(input_comment input_comment input_comment) }
+    let(:comment_to_delete) { double("comment_to_delete", :id => "comment_id") }
+    let(:comments_to_delete) { [comment_to_delete, comment_to_delete, comment_to_delete] }
+    let(:comments_out) { [Hash("html_url"=> url), Hash("key"=> "value")] }
+
+    it "should add commit status" do
+      expect(described_class).to receive(:issue_comments).with(repo, num).and_return(comments_to_delete)
+      expect(described_class).to receive(:delete_comments).with(repo, comments_to_delete.map(&:id))
+      expect(described_class).to receive(:add_comments).with(repo, num, comments_in).and_return(comments_out)
+      expect(described_class).to receive(:add_status).with(repo, sha, url, true).once
+
+      described_class.replace_comments(repo, num, comments_in, true, sha) { "something" }
     end
   end
 end

--- a/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/rubocop_checker_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe CommitMonitorHandlers::CommitRange::RubocopChecker do
+  describe "#replace_rubocop_comments" do
+    let(:num) { 42 }
+    let(:repo) { "owner/repository" }
+    let(:comments) { %w(comment1 comment2) }
+    let(:sha) { "b0e6911a4b7cc8dcf6aa4ed28244a1d5fb90d051" }
+    let(:commits) { ["x", "y", sha] }
+
+    let(:results_no_status) { Hash("files"=> [Hash("offenses"=> [Hash("severity"=>"warn"), Hash("severity"=>"info")]), Hash("offenses"=> [Hash("severity"=>"unknown"), Hash("severity"=>"info")])]) }
+    let(:results_red_status) { Hash("files"=> [Hash("offenses"=> [Hash("severity"=>"warn"), Hash("severity"=>"error")]), Hash("offenses"=> [Hash("severity"=>"fatal"), Hash("severity"=>"info")])]) }
+    let(:results_green_status) { Hash("files"=> [Hash("offenses"=> []), Hash("offenses"=> [])]) }
+
+    before do
+      allow(subject).to receive(:fq_repo_name).and_return(repo)
+      allow(subject).to receive(:pr_number).and_return(num)
+      allow(subject).to receive(:rubocop_comments).and_return(comments)
+      allow(subject).to receive(:commits).and_return(commits)
+    end
+
+    after do
+      subject.send(:replace_rubocop_comments)
+    end
+
+    it "should call replace_comments with :zero (green - success) status" do
+      allow(subject).to receive(:results).and_return(results_green_status)
+
+      expect(GithubService).to receive(:replace_comments).with(repo, num, comments, :zero, sha).once
+    end
+
+    it "should call replace_comments with :bomb (red - error) status" do
+      allow(subject).to receive(:results).and_return(results_red_status)
+
+      expect(GithubService).to receive(:replace_comments).with(repo, num, comments, :bomb, sha).once
+    end
+
+    it "should call replace_comments with :warn (green - success) status" do
+      allow(subject).to receive(:results).and_return(results_no_status)
+
+      expect(GithubService).to receive(:replace_comments).with(repo, num, comments, :warn, sha).once
+    end
+  end
+end


### PR DESCRIPTION
This is a rebase of https://github.com/ManageIQ/miq_bot/pull/412 

This only required the update of `spec/lib/github_service_spec.rb` to be modified to work with the new `GithubService` specs that were added back in 1173807a to support `#username_lookup` (since both commits added this file back).

See #412 for details on this feature.