### PR TITLE
Upgrade ruby in .travis.yml and Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@
 
 # Ignore local seeds file
 db/seeds.local.rb
+
+# Ignore vagrant configuration/runtime files
+.vagrant/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.5.5
+rvm: 2.5.7
 cache: bundler
 services:
 - postgresql

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,18 +16,12 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell", inline: <<-SHELL.gsub(/^ {4}/, '')
-    dnf install -y make patch gcc gcc-c++ cmake libssh2-devel
-    dnf install -y nodejs python-pip postgresql postgresql-server postgresql-devel
+    dnf install -y automake bison zlib-devel libyaml-devel openssl-devel           \
+                   gdbm-devel readline-devel ncurses-devel libffi-devel            \
+                   make patch gcc gcc-c++ cmake libssh2-devel ruby-devel rpm-build \
+                   nodejs python-pip postgresql postgresql-server postgresql-devel
 
     pip install yamllint
-
-    curl -L https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz > ruby-install-0.7.0.tar.gz
-    tar -xzvf ruby-install-0.7.0.tar.gz
-    cd ruby-install-0.7.0
-    make install
-    cd ..
-
-    ruby-install --system ruby-2.5.5
 
     cd /vagrant
     gem install bundler:1.17.3

--- a/config/database.vagrant.yml
+++ b/config/database.vagrant.yml
@@ -1,0 +1,20 @@
+---
+base: &base
+  adapter: postgresql
+  encoding: utf8
+  pool: 25
+  wait_timeout: 5
+
+development:
+  <<: *base
+  database: miq_bot_development
+
+production:
+  <<: *base
+  database: miq_bot_production
+
+test: &test
+  <<: *base
+  database: miq_bot_test
+  # Silence these: 'NOTICE:  CREATE TABLE will create...'
+  min_messages: warning


### PR DESCRIPTION
`ruby-install` was originally picked for the `Vagrantfile` to match what was in the `.travis.yml`, and `dnf` only had 2.5.7 available.  But based on output from the bot in production:

> Checked commit NickLaMuro@b68ddde with ruby 2.5.7 ...
>
> Ref: https://github.com/ManageIQ/miq_bot/pull/497#issuecomment-624154539

We are using 2.5.7 there as well, so switching to use a `dnf` install to speed up the the over all build time of the box.

Also updating the `.travis.yml` to use 2.5.7 as well.