### PR TITLE
GitService::Repo.git_fetch (and friends)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'slim'
 
 # Services gems
 gem 'minigit',        '~> 0.0.4'
+gem 'net-ssh',        '~> 4.2.0'
 gem 'tracker_api',    '~> 1.6'
 gem 'travis',         '~> 1.7.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
+    net-ssh (4.2.0)
     nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
@@ -415,6 +416,7 @@ DEPENDENCIES
   listen
   minigit (~> 0.0.4)
   more_core_extensions (~> 4.0.0)
+  net-ssh (~> 4.2.0)
   octokit (~> 4.8.0)
   pg
   rails (~> 5.2.2)

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -145,20 +145,8 @@ class Repo < ActiveRecord::Base
     results
   end
 
-  # TODO: Move this to GitService::Repo
   def git_fetch
-    # TODO: Figure out why this doesn't work on the bot using rugged
-    with_git_service { |git| git.fetch }
-    # require 'rugged'
-    # rugged_repo = Rugged::Repository.new(path.to_s)
-    # rugged_repo.remotes.each do |remote|
-    #   fetch_options = {}
-
-    #   username = extract_username_from_git_remote_url(remote.url)
-    #   fetch_options[:credentials] = Rugged::Credentials::SshKeyFromAgent.new(:username => username) if username
-
-    #   rugged_repo.fetch(remote.name, fetch_options)
-    # end
+    git_service.git_fetch
   end
 
   def create_branch!(branch_name)

--- a/lib/git_service/credentials.rb
+++ b/lib/git_service/credentials.rb
@@ -1,5 +1,13 @@
 module GitService
   class Credentials
+    # Generic method for finding git credentials based on what is available
+    #
+    # Will use ssh_agent if all other options have been exhausted.
+    #
+    def self.find_for_user_and_host(username, hostname)
+      from_ssh_agent(username)
+    end
+
     def self.from_ssh_agent(username)
       Rugged::Credentials::SshKeyFromAgent.new(:username => username)
     end

--- a/lib/git_service/credentials.rb
+++ b/lib/git_service/credentials.rb
@@ -1,0 +1,7 @@
+module GitService
+  class Credentials
+    def self.from_ssh_agent(username)
+      Rugged::Credentials::SshKeyFromAgent.new(:username => username)
+    end
+  end
+end

--- a/lib/git_service/credentials.rb
+++ b/lib/git_service/credentials.rb
@@ -1,11 +1,39 @@
 module GitService
   class Credentials
+    # Example:
+    #
+    #   GitService::Credentials.host_config = {
+    #     '*' => {
+    #       :username    => 'git',
+    #       :private_key => '~/.ssh/id_rsa'
+    #     },
+    #     'github.com' => {
+    #       :username    => 'git',
+    #       :private_key => '~/.ssh/id_rsa'
+    #     }
+    #   }
+    #
+    def self.host_config=(host_config = {})
+      @host_config = host_config.to_h
+    end
+
     # Generic method for finding git credentials based on what is available
     #
     # Will use ssh_agent if all other options have been exhausted.
     #
     def self.find_for_user_and_host(username, hostname)
-      from_ssh_agent(username)
+      from_ssh_config(username, hostname) || from_ssh_agent(username)
+    end
+
+    def self.from_ssh_config(username, hostname)
+      ssh_config = Net::SSH::Config.for(hostname)
+
+      return if ssh_config.empty? || ssh_config[:keys].nil?
+
+      ssh_config[:username]   = username || ssh_config[:user]             # favor URL username if present
+      ssh_config[:privatekey] = File.expand_path(ssh_config[:keys].first) # only use first key
+
+      Rugged::Credentials::SshKey.new(ssh_config)
     end
 
     def self.from_ssh_agent(username)

--- a/lib/git_service/repo.rb
+++ b/lib/git_service/repo.rb
@@ -12,9 +12,11 @@ module GitService
       require 'rugged'
       rugged_repo.remotes.each do |remote|
         fetch_options = {}
+        username      = uri_for_remote(remote.url).user
+        hostname      = uri_for_remote(remote.url).hostname
+        credentials   = Credentials.find_for_user_and_host(username, hostname)
 
-        username = uri_for_remote(remote.url).user
-        fetch_options[:credentials] = Credentials.from_ssh_agent(username) if username
+        fetch_options[:credentials] = credentials if credentials
 
         rugged_repo.fetch(remote.name, fetch_options)
       end

--- a/lib/git_service/repo.rb
+++ b/lib/git_service/repo.rb
@@ -14,7 +14,7 @@ module GitService
         fetch_options = {}
 
         username = extract_username_from_git_remote_url(remote.url)
-        fetch_options[:credentials] = Rugged::Credentials::SshKeyFromAgent.new(:username => username) if username
+        fetch_options[:credentials] = Credentials.from_ssh_agent(username) if username
 
         rugged_repo.fetch(remote.name, fetch_options)
       end

--- a/lib/git_service/repo.rb
+++ b/lib/git_service/repo.rb
@@ -8,10 +8,26 @@ module GitService
       GitService::Commit.new(rugged_repo, sha)
     end
 
+    def git_fetch
+      require 'rugged'
+      rugged_repo.remotes.each do |remote|
+        fetch_options = {}
+
+        username = extract_username_from_git_remote_url(remote.url)
+        fetch_options[:credentials] = Rugged::Credentials::SshKeyFromAgent.new(:username => username) if username
+
+        rugged_repo.fetch(remote.name, fetch_options)
+      end
+    end
+
     private
 
     def rugged_repo
       @rugged_repo ||= Rugged::Repository.new(@repo.path.to_s)
+    end
+
+    def extract_username_from_git_remote_url(url)
+      url.start_with?("http") ? nil : url.match(/^.+?(?=@)/).to_s.presence
     end
   end
 end


### PR DESCRIPTION
This PR does a bunch of things to try and allow `.git_fetch` to work from `Rugged`:

- Moves logic for `Rugged` based `.git_fetch` into `GitService::Repo`
- Adds a `GitService::Credentials` in charge of finding credentials for a given remote/user
- Adds logic in `GitService::Credentials` to allow configuration of keys by host ~~(similar to `~/.ssh/config`)~~ using `~/.ssh/config` via the `net-ssh` gem
- Uses new `.git_fetch` and credential finding in `Repo` model
- Initializes git credentials (if configured) on Rails boot

Example config
---------------

~~This is what I am using for my ssh configuration for in my `config/settings/development.local.yml`:~~

**NOT NEEDED/USED.  Use example `~/.ssh/config` below instead:**

```yaml
git_service_hostname_ssh_config:
  '*':
    username: git
    privatekey: /full/path/to/.ssh/id_rsa
```

~~Full paths are required, it seems, and it will bomb when using `~/.ssh/id_rsa`.~~


This is what is in my `~/.ssh/config` for testing this:

```config
Host *
  AddKeysToAgent yes
  UseKeychain no
  IdentityFile ~/.ssh/id_rsa
```

(note:  I think `AddKeysToAgent` probably could be set to `no`, but I haven't tested)