### PR TITLE
Switch to using manageiq-style for linting dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
+inherit_gem:
+  manageiq-style: .rubocop_base.yml
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
 # put all local rubocop config into .rubocop_local.yml as it will be loaded by .rubocop_cc.yml as well
 - .rubocop_local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,8 @@ gem 'awesome_spawn',        '>= 1.4.1'
 gem 'default_value_for',    '>= 3.1.0'
 gem 'haml',                 '~> 5.1',    :require => false # force newer version of haml
 gem 'haml_lint',            '~> 0.35.0', :require => false
+gem 'manageiq-style',                    :require => false
 gem 'more_core_extensions', '~> 4.0.0',  :require => 'more_core_extensions/all'
-gem 'rubocop',              '~> 0.82.0', :require => false
-gem 'rubocop-performance',               :require => false
-gem 'rubocop-rails',                     :require => false
 gem 'rugged',                            :require => false
 
 gem 'octokit', '~> 4.8.0', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       sysexits (~> 1.1)
     hashdiff (1.0.0)
     highline (1.7.10)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     ice_cube (0.14.0)
     ice_nine (0.11.2)
@@ -190,6 +190,10 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    manageiq-style (1.0.1)
+      rubocop (~> 0.82.0)
+      rubocop-performance
+      rubocop-rails
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
@@ -197,7 +201,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minigit (0.0.4)
-    minitest (5.14.0)
+    minitest (5.14.1)
     more_core_extensions (4.0.0)
       activesupport
     multi_json (1.14.1)
@@ -211,9 +215,9 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.19.1)
-    parser (2.7.1.3)
-      ast (~> 2.4.0)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     pg (1.2.2)
     pry (0.9.12.6)
       coderay (~> 1.0)
@@ -291,12 +295,12 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-performance (1.5.2)
+    rubocop-performance (1.6.1)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.5.2)
-      activesupport
+    rubocop-rails (2.6.0)
+      activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 0.72.0)
+      rubocop (>= 0.82.0)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     rugged (0.28.4.1)
@@ -377,7 +381,7 @@ GEM
     turbolinks-source (5.2.0)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unicode-display_width (1.7.0)
@@ -413,6 +417,7 @@ DEPENDENCIES
   influxdb (~> 0.3.13)
   jquery-rails
   listen
+  manageiq-style
   minigit (~> 0.0.4)
   more_core_extensions (~> 4.0.0)
   octokit (~> 4.8.0)
@@ -420,9 +425,6 @@ DEPENDENCIES
   rails (~> 5.2.2)
   rspec
   rspec-rails
-  rubocop (~> 0.82.0)
-  rubocop-performance
-  rubocop-rails
   rugged
   sass-rails (~> 5.0.7)
   sidekiq (~> 5.2.5)


### PR DESCRIPTION
- [ ] https://github.com/ManageIQ/amazon_ssa_support/pull/50
- [ ] https://github.com/ManageIQ/dbus_api_service/pull/19
- [ ] https://github.com/ManageIQ/httpd_configmap_generator/pull/50
- [ ] https://github.com/ManageIQ/log_decorator/pull/12
- [ ] https://github.com/ManageIQ/manageiq-api/pull/845
- [ ] https://github.com/ManageIQ/manageiq-appliance/pull/286
- [ ] https://github.com/ManageIQ/manageiq-appliance-build/pull/419
- [ ] https://github.com/ManageIQ/manageiq-appliance_console/pull/127
- [ ] https://github.com/ManageIQ/manageiq-automation_engine/pull/458
- [ ] https://github.com/ManageIQ/manageiq-consumption/pull/180
- [ ] https://github.com/ManageIQ/manageiq-content/pull/669
- [ ] https://github.com/ManageIQ/manageiq-decorators/pull/36
- [ ] https://github.com/ManageIQ/manageiq-gems-pending/pull/491
- [ ] https://github.com/ManageIQ/manageiq-graphql/pull/86
- [ ] https://github.com/ManageIQ/manageiq-messaging/pull/49
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/625
- [ ] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/222
- [ ] https://github.com/ManageIQ/manageiq-providers-autosde/pull/34
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/396
- [ ] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/41
- [ ] https://github.com/ManageIQ/manageiq-providers-foreman/pull/64
- [ ] https://github.com/ManageIQ/manageiq-providers-google/pull/160
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/89
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/9
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/379
- [ ] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/172
- [ ] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/303
- [ ] https://github.com/ManageIQ/manageiq-providers-nsxt/pull/21
- [ ] https://github.com/ManageIQ/manageiq-providers-nuage/pull/228
- [ ] https://github.com/ManageIQ/manageiq-providers-openshift/pull/181
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/588
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/495
- [ ] https://github.com/ManageIQ/manageiq-providers-redfish/pull/125
- [ ] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/167
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/581
- [ ] https://github.com/ManageIQ/manageiq-rpm_build/pull/50
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/488
- [ ] https://github.com/ManageIQ/manageiq-smartstate/pull/143
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/7073
- [ ] https://github.com/ManageIQ/manageiq/pull/20185
- [ ] https://github.com/ManageIQ/manageiq-v2v/pull/1145
- [ ] https://github.com/ManageIQ/activerecord-id_regions/pull/16
- [ ] https://github.com/ansible/ansible_tower_client_ruby/pull/142
- [ ] https://github.com/ManageIQ/azure-armrest/pull/396
- [ ] https://github.com/ManageIQ/linux_admin/pull/219