### PR TITLE
[stale_issue_marker.rb] Fix 'updated' search

### DIFF
--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -28,7 +28,7 @@ class StaleIssueMarker
   private
 
   def handle_newly_stale_issues
-    query  = "is:open archived:false update:<#{stale_date.strftime('%Y-%m-%d')}"
+    query  = "is:open archived:false updated:<#{stale_date.strftime('%Y-%m-%d')}"
     query << enabled_repos_query_filter
     query << unpinned_query_filter
 

--- a/spec/workers/stale_issue_marker_spec.rb
+++ b/spec/workers/stale_issue_marker_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe StaleIssueMarker do
   let(:search_query)      { "#{issue_filter} #{update_filter} #{repo_filter} #{pinned_filter}" }
   let(:unmergeable_query) { "#{issue_filter} is:pr #{labels_filter} #{repo_filter} #{pinned_filter}" }
   let(:issue_filter)      { "is:open archived:false" }
-  let(:update_filter)     { "update:<#{stale_date.strftime('%Y-%m-%d')}" }
+  let(:update_filter)     { "updated:<#{stale_date.strftime('%Y-%m-%d')}" }
   let(:repo_filter)       { %(repo:"#{fq_repo_name}") }
   let(:pinned_filter)     { %(-label:"pinned") }
   let(:labels_filter)     { %(label:"stale" label:"unmergeable") }


### PR DESCRIPTION
`updated:<` should be the keyword used, not `update:<`, as shown by the difference in these two searches:

**Returns no records**

https://github.com/search?q=org%3AManageIQ+is%3Aopen+archived%3Afalse+update%3A%3C2020-03-01+-label%3Apinned&type=Issues

**Returns (a bunch of) records**

https://github.com/search?q=org%3AManageIQ+is%3Aopen+archived%3Afalse+updated%3A%3C2020-03-01+-label%3Apinned&type=Issues