### PR TITLE
Use .close_issue instead of .close_pull_request

### DIFF
--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -116,7 +116,7 @@ class StaleIssueMarker
     message << COMMENT_FOOTER
 
     logger.info("[#{Time.now.utc}] - Closing stale #{issue.type} #{issue.fq_repo_name}##{issue.number}")
-    GithubService.close_pull_request(issue.fq_repo_name, issue.number)
+    GithubService.close_issue(issue.fq_repo_name, issue.number)
     issue.add_comment(message)
   end
 end

--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -9,7 +9,7 @@ class StaleIssueMarker
   SEARCH_SORTING = {:sort => :updated, :direction => :asc}.freeze
   COMMENT_FOOTER = <<~FOOTER.sub("ManageIQ\n", "ManageIQ ").strip!
     Thank you for all your contributions!  More information about the ManageIQ
-    triage process can be found in [the traige process documentation][1].
+    triage process can be found in [the triage process documentation][1].
 
     [1]: https://www.manageiq.org/docs/guides/triage_process
   FOOTER

--- a/app/workers/stale_issue_marker.rb
+++ b/app/workers/stale_issue_marker.rb
@@ -115,7 +115,7 @@ class StaleIssueMarker
     message << "this issue is still valid.\n\n"     unless issue.pull_request?
     message << COMMENT_FOOTER
 
-    logger.info("[#{Time.now.utc}] - Closing stale PR #{issue.fq_repo_name}##{issue.number}")
+    logger.info("[#{Time.now.utc}] - Closing stale #{issue.type} #{issue.fq_repo_name}##{issue.number}")
     GithubService.close_pull_request(issue.fq_repo_name, issue.number)
     issue.add_comment(message)
   end

--- a/spec/workers/stale_issue_marker_spec.rb
+++ b/spec/workers/stale_issue_marker_spec.rb
@@ -99,10 +99,10 @@ RSpec.describe StaleIssueMarker do
 
       if [already_stale_issue, stale_and_unmergable_pr, old_unmergable_pr].include?(issue)
         expect(issue).to receive(:add_comment).with(/This (pull request|issue).*closed/)
-        expect(GithubService).to receive(:close_pull_request).with(fq_repo_name, issue.number)
+        expect(GithubService).to receive(:close_issue).with(fq_repo_name, issue.number)
       else
         expect(issue).to receive(:add_comment).with(/This (pull request|issue).*marked as stale/)
-        expect(GithubService).to_not receive(:close_pull_request).with(issue.number)
+        expect(GithubService).to_not receive(:close_issue).with(issue.number)
       end
     end
   end


### PR DESCRIPTION
Since it works for both PRs and issues.

Also fixes:

- A typo: `s/traige/triage/`
- Logging inconsistency:  Now using `issue.type` to denote the difference between closing an issue and a PR in the logs