### PR TITLE
Ensure the clone is always up to date before returning a GitService::Repo

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -161,6 +161,7 @@ class Repo < ActiveRecord::Base
   end
 
   def git_service
+    git_fetch
     GitService::Repo.new(self)
   end
 


### PR DESCRIPTION
In a podified deployment with the queues running in different pods and the pods each having their own clones of the repos, we can't depend on other jobs having already fetched for the clone.