### PR TITLE
For cross-repo-test, make PR Name more specific

### DIFF
--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -243,7 +243,7 @@ module GithubService
 
         GithubService.create_pull_request(fq_repo_name,
                                           "master", branch_name,
-                                          "[BOT] Cross repo test run", pr_desc)
+                                          "[BOT] Cross repo test for #{issue.fq_repo_name}##{issue.number}", pr_desc)
       end
 
       ##### Duplicate Git stuffs #####

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       pull_request_data = {
         "base"  => "master",
         "head"  => subject.branch_name,
-        "title" => "[BOT] Cross repo test run",
+        "title" => "[BOT] Cross repo test for ManageIQ/bar#1234",
         "body"  => <<~PR_BODY
           From Pull Request:  ManageIQ/bar#1234
           For User:           @NickLaMuro


### PR DESCRIPTION
This avoids each auto-generated PR to have the identical name of `[BOT] Cross repo test run`

Follow-up to https://github.com/ManageIQ/miq_bot/pull/454