### PR TITLE
Process repository groups in cross-repo-tests command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ underscores replaced with hyphens.
     since there is no code to run.
 
   Example: `@miq-bot cross_repo_tests ManageIQ/manageiq#1234 including more_core_extensions@1234abcd`
+  
+  Also accepts repository groups, e.g. `/providers`, `/core`, `/all`
+  Example: `@miq-bot cross_repo_tests ManageIQ/manageiq#1234, /providers including more_core_extensions@1234abcd
 
 ## Development
 

--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -279,7 +279,7 @@ module GithubService
         response = Net::HTTP.get_response(uri)
         return {} if response.code != 200
 
-        YAML.load(response.body).transform_values(&:keys)
+        YAML.safe_load(response.body, :aliases => true).transform_values(&:keys)
       end
       private_class_method :fetch_manageiq_release_repo_groups
 

--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -75,6 +75,9 @@ module GithubService
 
       restrict_to :organization
 
+      # Cache the repo groups yaml file from https://github.com/ManageIQ/manageiq-release
+      cache_with_timeout(:repo_groups_hash, 60.minutes) { fetch_manageiq_release_repo_groups }
+
       def self.test_repo_url
         Settings.cross_repo_tests.url
       end
@@ -134,16 +137,35 @@ module GithubService
         @value = value
 
         @test_repos, @repos = value.split(/\s+including\s+/)
-                                   .map { |repo_list| repo_list.split(",") }
+                                   .map { |repo_list| repo_list.split(",").map(&:strip) }
 
         # Add the identifier for the PR for this comment to @repos here
         @repos ||= []
         @repos  << "#{issue.repo_name}##{issue.number}"
 
+        repo_groups, @test_repos = @test_repos.partition { |repo_name| repo_name.start_with?("/") }
+        @test_repos += expand_repo_groups(repo_groups)
+
         @test_repos.map! { |repo_name| normalize_repo_name(repo_name.strip) }
         @repos.map!      { |repo_name| normalize_repo_name(repo_name.strip) }
 
         [@repos, @test_repos].each(&:uniq!)
+      end
+
+      def expand_repo_groups(repo_groups)
+        # Expand out each group and prioritize any repos which were passed explicitly
+        # in the test_repos list by the user
+        #
+        # E.g. `cross-repo manageiq-providers-amazon#1234 /providers` should only
+        # include manageiq-providers-amazon#1234
+        repo_groups.flat_map { |repo_group| expand_repo_group(repo_group) }
+                   .reject { |repo_name| @test_repos.any? { |test_repo| test_repo.include?(repo_name) } }
+      end
+
+      def expand_repo_group(repo_group)
+        # repo_group is of the format "/providers"
+        key = repo_group.sub("/", "")
+        self.class.repo_groups_hash[key]
       end
 
       def normalize_repo_name(repo)
@@ -245,6 +267,18 @@ module GithubService
                                           "master", branch_name,
                                           "[BOT] Cross repo test for #{issue.fq_repo_name}##{issue.number}", pr_desc)
       end
+
+      def self.fetch_manageiq_release_repo_groups
+        require 'net/http'
+        require 'uri'
+
+        uri = URI.parse("https://raw.githubusercontent.com/ManageIQ/manageiq-release/master/config/repos.sets.yml")
+        response = Net::HTTP.get_response(uri)
+        return {} if response.code != 200
+
+        YAML.load(response.body).transform_values(&:keys)
+      end
+      private_class_method :fetch_manageiq_release_repo_groups
 
       ##### Duplicate Git stuffs #####
 

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -285,7 +285,9 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
   end
 
   describe "#parse_value (private)" do
+    let(:repo_groups_hash) { {} }
     before do
+      allow(described_class).to receive(:repo_groups_hash).and_return(repo_groups_hash)
       subject.send(:parse_value, command_value)
     end
 
@@ -300,6 +302,37 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       it "sets @test_repos and @repos" do
         expect(subject.test_repos).to eq ["ManageIQ/manageiq-ui-classic"]
         expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
+      end
+    end
+
+    context "with repo groups" do
+      let(:repo_groups_hash) { {"providers" => ["manageiq-providers-amazon", "manageiq-providers-azure"]} }
+
+      context "with just /providers group" do
+        let(:command_value) { "/providers" }
+
+        it "sets @test_repos and @repos" do
+          expect(subject.test_repos).to eq ["ManageIQ/manageiq-providers-amazon", "ManageIQ/manageiq-providers-azure"]
+          expect(subject.repos).to      eq [issue_identifier]
+        end
+      end
+
+      context "with /providers group and including" do
+        let(:command_value) { "/providers including manageiq#1234" }
+
+        it "sets @test_repos and @repos" do
+          expect(subject.test_repos).to eq ["ManageIQ/manageiq-providers-amazon", "ManageIQ/manageiq-providers-azure"]
+          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
+        end
+      end
+
+      context "with a test PR and a group" do
+        let(:command_value) { "manageiq-providers-amazon#1234, /providers including manageiq#1234" }
+
+        it "sets @test_repos and @repos" do
+          expect(subject.test_repos).to eq ["ManageIQ/manageiq-providers-amazon#1234", "ManageIQ/manageiq-providers-azure"]
+          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
+        end
       end
     end
 

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -334,6 +334,15 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
           expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
         end
       end
+
+      context "with a test repo that contains a substring of a provider group" do
+        let(:command_value) { "manageiq-providers-azure_stack#1234, /providers including manageiq#1234" }
+
+        it "sets @test_repos and @repos" do
+          expect(subject.test_repos).to eq ["ManageIQ/manageiq-providers-azure_stack#1234", "ManageIQ/manageiq-providers-amazon", "ManageIQ/manageiq-providers-azure"]
+          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
+        end
+      end
     end
 
     context "multiple repos and test repos" do


### PR DESCRIPTION
Allow for users to specify groups of repositories with a simple `/group-name` directive.
These groups can be defined dynamically in manageiq-release config as yaml files.

Example: `@miq-bot cross_repo_tests /providers including manageiq#1234`

TODO
- [x] Define the repo groups yaml file in manageiq-release https://github.com/ManageIQ/manageiq-release/pull/169