### PR TITLE
Fix container build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ LABEL name="miq-bot" \
       io.k8s.description="ManageIQ Bot is a developer automation tool." \
       io.openshift.tags="ManageIQ,miq-bot"
 
-RUN dnf -y --disableplugin=subscription-manager install \
+RUN dnf config-manager --setopt=ubi-8-*.exclude=net-snmp*,dracut*,libcom_err*,python3-gobject*,redhat-release* --save && \
+    dnf -y --disableplugin=subscription-manager install \
       unzip \
       wget \
       http://mirror.centos.org/centos/8.2.2004/BaseOS/x86_64/os/Packages/centos-repos-8.2-2.2004.0.1.el8.x86_64.rpm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN dnf config-manager --setopt=ubi-8-*.exclude=net-snmp*,dracut*,libcom_err*,py
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf -y --disableplugin=subscription-manager module enable nodejs:12 && \
     dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
-    dnf -y --disableplugin=subscription-manager upgrade && \
+    dnf -y --disableplugin=subscription-manager upgrade --exclude=filesystem && \
     dnf clean all
 
 RUN wget https://github.com/ManageIQ/miq_bot/archive/$REF.zip && \


### PR DESCRIPTION
- Exclude RHEL 8.3 packages that conflict with CentOS 8.2 (Based on https://github.com/ManageIQ/manageiq-pods/pull/648)
- Skip filesystem RPM for now, there's an issue installing the new one (https://access.redhat.com/solutions/2381811)
