### PR TITLE
Ensure test_repos that are branches/PRs are part of the repos list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,20 @@ underscores replaced with hyphens.
   Example: `@miq-bot close_issue`
 
 - **`cross_repo_test test_repos* [including include_repos*]`**
-  Runs cross repo tests that include the current PR code base.
+  Runs cross repo tests that include the current PR code base. A pull request will
+  be created in the [manageiq-cross_repo-tests repo](https://github.com/ManageIQ/manageiq-cross_repo-tests)
+  where each of the `test_repos` will be a separate entry in the test matrix. Those
+  tests will run in the context of all repos declared in `test_repos` +
+  `include_repos` + the PR itself.
 
   * This command is restricted to members of the organization containing the issue.
   * Restricted use on pull requests.  This doesn't make sense to use on issues
     since there is no code to run.
 
   Example: `@miq-bot cross_repo_tests ManageIQ/manageiq#1234 including more_core_extensions@1234abcd`
-  
+
   Also accepts repository groups, e.g. `/providers`, `/core`, `/all`
+
   Example: `@miq-bot cross_repo_tests ManageIQ/manageiq#1234, /providers including more_core_extensions@1234abcd
 
 ## Development

--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -49,11 +49,6 @@ module GithubService
     #   -  - TEST_REPO=
     #   +  - TEST_REPO=ManageIQ/manageiq-api
     #   +  - TEST_REPO=ManageIQ/manageiq-ui-classic#5678
-    #
-    # TODO:  Handle the "self" case, where `manageiq` is also a TEST_REPO
-    #
-    # (maybe include a "self" helper as well?)
-    #
     class CrossRepoTest < Base
       # Reference to the branch we are creating off of origin/master
       attr_reader :branch_ref

--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -147,6 +147,9 @@ module GithubService
         # Add the identifier for the PR for this comment to repos
         @repos << "#{issue.repo_name}##{issue.number}"
 
+        # Add any test_repos that are branches or PRs to the repos list
+        @repos |= @test_repos.select { |repo| branch_or_pr?(repo) }
+
         # Clean up the lists
         @test_repos = @test_repos.map { |repo| normalize_repo_name(repo) }.sort.uniq
         @repos      = @repos.map      { |repo| normalize_repo_name(repo) }.sort.uniq

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -286,6 +286,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
 
   describe "#parse_value (private)" do
     let(:repo_groups_hash) { {} }
+
     before do
       allow(described_class).to receive(:repo_groups_hash).and_return(repo_groups_hash)
       subject.send(:parse_value, command_value)
@@ -296,12 +297,30 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       expect(subject.repos).to      eq [issue_identifier]
     end
 
-    context "with 'including' argument" do
-      let(:command_value) { "manageiq-ui-classic including manageiq#1234" }
+    context "without 'including' argument" do
+      let(:command_value) { "manageiq-ui-classic#1234, manageiq-api" }
 
       it "sets @test_repos and @repos" do
-        expect(subject.test_repos).to eq ["ManageIQ/manageiq-ui-classic"]
-        expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
+        expect(subject.test_repos).to eq ["ManageIQ/manageiq-api", "ManageIQ/manageiq-ui-classic#1234"]
+        expect(subject.repos).to      eq ["ManageIQ/manageiq-ui-classic#1234", issue_identifier].sort
+      end
+    end
+
+    context "with 'including' argument" do
+      let(:command_value) { "manageiq-ui-classic#1234, manageiq-api including manageiq#2345" }
+
+      it "sets @test_repos and @repos" do
+        expect(subject.test_repos).to eq ["ManageIQ/manageiq-api", "ManageIQ/manageiq-ui-classic#1234"]
+        expect(subject.repos).to      eq ["ManageIQ/manageiq#2345", "ManageIQ/manageiq-ui-classic#1234", issue_identifier].sort
+      end
+    end
+
+    context "with 'including' argument that is also listed as a test_repo" do
+      let(:command_value) { "manageiq-ui-classic#1234, manageiq-api including manageiq-ui-classic#1234" }
+
+      it "sets @test_repos and @repos" do
+        expect(subject.test_repos).to eq ["ManageIQ/manageiq-api", "ManageIQ/manageiq-ui-classic#1234"]
+        expect(subject.repos).to      eq ["ManageIQ/manageiq-ui-classic#1234", issue_identifier].sort
       end
     end
 
@@ -322,7 +341,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
 
         it "sets @test_repos and @repos" do
           expect(subject.test_repos).to eq ["ManageIQ/manageiq-providers-amazon", "ManageIQ/manageiq-providers-azure"]
-          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
+          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier].sort
         end
       end
 
@@ -331,7 +350,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
 
         it "sets @test_repos and @repos" do
           expect(subject.test_repos).to eq ["ManageIQ/manageiq-providers-amazon#1234", "ManageIQ/manageiq-providers-azure"]
-          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
+          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", "ManageIQ/manageiq-providers-amazon#1234", issue_identifier].sort
         end
       end
 
@@ -339,8 +358,8 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
         let(:command_value) { "manageiq-providers-azure_stack#1234, /providers including manageiq#1234" }
 
         it "sets @test_repos and @repos" do
-          expect(subject.test_repos).to eq ["ManageIQ/manageiq-providers-azure_stack#1234", "ManageIQ/manageiq-providers-amazon", "ManageIQ/manageiq-providers-azure"]
-          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", issue_identifier]
+          expect(subject.test_repos).to eq ["ManageIQ/manageiq-providers-amazon", "ManageIQ/manageiq-providers-azure", "ManageIQ/manageiq-providers-azure_stack#1234"]
+          expect(subject.repos).to      eq ["ManageIQ/manageiq#1234", "ManageIQ/manageiq-providers-azure_stack#1234", issue_identifier].sort
         end
       end
     end
@@ -357,7 +376,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
           Fryguy/more_core_extensions@feature
           ManageIQ/linux_admin#123
           #{issue_identifier}
-        ]
+        ].sort
       }
 
       context "with no spaces" do


### PR DESCRIPTION
Example (assuming the PR in questions is `manageiq#1234`)

`@miq-bot cross_repo_test manageiq-api#2345, manageiq-ui-classic#3456` would produce:

```diff
-REPOS=ManageIQ/manageiq#1234
+REPOS=ManageIQ/manageiq#1234,ManageIQ/manageiq-api#2345,ManageIQ/manageiq-ui-classic#3456
 ...
 TEST_REPO=ManageIQ/manageiq-api#2345
 TEST_REPO=ManageIQ/manageiq-ui-classic#3456
```

---

The "Before" is not accurate because the tests are not running within the entire suite of changes as can be seen in the "After".  Thus, this change no longer puts the onus on the developer to remember to add everything (again) in the including section.




@agrare Please review.