### PR TITLE
Ignore spec data in rubocop

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,0 +1,3 @@
+AllCops:
+  Exclude:
+  - spec/workers/commit_monitor_handlers/commit_range/rubocop_checker/data/**/*


### PR DESCRIPTION
This data has intentional errors in it so that when the bot runs rubocop
it can pick up real errors (and thus report on them).

Partial fix for #538 (drops the number of offenses in this repo from 121
to 18)