### PR TITLE
Rubocop fixes

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -31,7 +31,7 @@ class Branch < ActiveRecord::Base
   end
 
   def self.with_branch_or_pr_number(n)
-    n = MinigitService.pr_branch(n) if n.kind_of?(Fixnum)
+    n = MinigitService.pr_branch(n) if n.kind_of?(Integer)
     where(:name => n)
   end
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -287,7 +287,7 @@ module GithubService
         response.value
 
         YAML.safe_load(response.body, :aliases => true).transform_values(&:keys)
-      rescue => err
+      rescue
         # If the get_response call fails return an empty hash
         {}
       end

--- a/lib/threadsafe_service_mixin.rb
+++ b/lib/threadsafe_service_mixin.rb
@@ -1,5 +1,3 @@
-require "thread"
-
 module ThreadsafeServiceMixin
   extend ActiveSupport::Concern
 

--- a/spec/lib/pivotal_service_spec.rb
+++ b/spec/lib/pivotal_service_spec.rb
@@ -43,3 +43,5 @@ EOMSG
     end
   end
 end
+
+# rubocop:enable Style/NumericLiterals

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -316,7 +316,7 @@ describe Repo do
     end
 
     it "handles pruning PR branches" do
-      pr_branch = create(:pr_branch, :repo => repo)
+      create(:pr_branch, :repo => repo)
 
       expect(repo).to receive(:git_fetch)
 


### PR DESCRIPTION
Just a small PR that addresses some linter issues brought up in https://github.com/ManageIQ/miq_bot/issues/538:

* Use Integer instead of Fixnum
* Remove unused variables
* Re-enable a cop when finished
* File.exist? vs File.exists?
* ~~Make private class methods private~~
* Remove unnecessary require