### PR TITLE
Handle bare PR numbers in cross-repo-test

### DIFF
--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -177,7 +177,9 @@ module GithubService
 
       def normalize_repo_name(repo)
         repo = repo.strip
-        repo.include?("/") ? repo : "#{issue.organization_name}/#{repo}"
+        repo = "#{issue.repo_name}#{repo}" if repo.start_with?("#")
+        repo = "#{issue.organization_name}/#{repo}" unless repo.include?("/")
+        repo
       end
 
       # Deduplicates entries sharing the same bare repo name, prioritizing

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -250,6 +250,34 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
         end
       end
 
+      context "with the PR itself in the test repo list" do
+        let(:command_value) { "#2345" }
+
+        it "is invalid" do
+          stub_issue_comment(<<~COMMENT)
+            @NickLaMuro 'cross-repo-test(s)' was given conflicting repo names and cannot continue
+
+            * `ManageIQ/bar#1234`, `ManageIQ/bar#2345` conflict
+          COMMENT
+
+          assert_execute(:valid => false)
+        end
+      end
+
+      context "with the PR itself in the included repos list" do
+        let(:command_value) { "manageiq-ui-classic including #2345" }
+
+        it "is invalid" do
+          stub_issue_comment(<<~COMMENT)
+            @NickLaMuro 'cross-repo-test(s)' was given conflicting repo names and cannot continue
+
+            * `ManageIQ/bar#1234`, `ManageIQ/bar#2345` conflict
+          COMMENT
+
+          assert_execute(:valid => false)
+        end
+      end
+
       context "with multiple conflicts in test repos list" do
         let(:command_value) { "manageiq-ui-classic#1234, manageiq-ui-classic#2345, manageiq-api#1234, manageiq-api#2345" }
 


### PR DESCRIPTION
For example,

If in PR `Foo/bar#1234`, if someone does, `@miq-bot cross-repo-test #2345`, then it will fail showing a conflict between `Foo/bar#1234` and `Foo/bar#2345`.  Note that a bare PR number will always conflict, so we could change this to fail-fast, but I thought the conflict error message would be much cleaner.