### PR TITLE
Fix recursive bot commands

### DIFF
--- a/lib/github_service.rb
+++ b/lib/github_service.rb
@@ -11,6 +11,10 @@ module GithubService
   # may already be well handled by Octokit itself.
   #
   class << self
+    def bot_name
+      Settings.github_credentials.username
+    end
+
     def add_comments(fq_repo_name, issue_number, comments)
       Array(comments).each do |comment|
         add_comment(fq_repo_name, issue_number, comment)
@@ -137,8 +141,8 @@ module GithubService
 
           unless Rails.env.test?
             Octokit.configure do |c|
-              c.login    = Settings.github_credentials.username
-              c.password = Settings.github_credentials.password
+              c.login         = bot_name
+              c.password      = Settings.github_credentials.password
               c.auto_paginate = true
 
               c.middleware = Faraday::RackBuilder.new do |builder|

--- a/lib/github_service/command_dispatcher.rb
+++ b/lib/github_service/command_dispatcher.rb
@@ -26,6 +26,7 @@ module GithubService
       lines.each do |line|
         match = command_regex.match(line.strip)
         next unless match
+        next if issuer == bot_name
 
         command       = match[:command]
         command_value = match[:command_value]

--- a/lib/github_service/command_dispatcher.rb
+++ b/lib/github_service/command_dispatcher.rb
@@ -52,7 +52,7 @@ Accepted commands are: #{self.class.registry.keys.join(", ")}
     end
 
     def bot_name
-      @bot_name ||= Settings.github_credentials.username
+      GithubService.bot_name
     end
   end
 end

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -62,7 +62,7 @@ module GithubService
       end
 
       def invalid_label_message(issuer, invalid_labels)
-        message  = "@#{issuer} "
+        message  = issuer == GithubService.bot_name ? "" : "@#{issuer} "
         message << "Cannot apply the following label"
         message << "s" if invalid_labels.length > 1
         message << " because they are not recognized:\n"

--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -92,7 +92,7 @@ module GithubService
       end
 
       def self.bot_name
-        Settings.github_credentials.username
+        GithubService.bot_name
       end
 
       def self.bot_email

--- a/spec/lib/github_service/command_dispatcher_spec.rb
+++ b/spec/lib/github_service/command_dispatcher_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe GithubService::CommandDispatcher do
         expect(command_class).to receive(:execute!)
           .with(:issuer => command_issuer, :value => "chrisarcand")
       end
+
+      context "if the bot is the target" do
+        let(:command_issuer) { bot_name }
+
+        it "does nothing" do
+          expect(GithubService::Commands::Assign).to receive(:new).never
+          expect(command_class).to receive(:execute!).never
+        end
+      end
     end
 
     context "when 'add_labels' command is given" do

--- a/spec/lib/github_service/commands/add_label_spec.rb
+++ b/spec/lib/github_service/commands/add_label_spec.rb
@@ -74,8 +74,23 @@ RSpec.describe GithubService::Commands::AddLabel do
     end
 
     it "does not add invalid labels and comments on error" do
+      issuer = "@#{command_issuer}"
+
       expect(issue).not_to receive(:add_labels)
-      expect(issue).to receive(:add_comment).with(/Cannot apply the following label.*not recognized/)
+      expect(issue).to receive(:add_comment).with(/^#{issuer} Cannot apply the following label.*not recognized/)
+    end
+
+    context "with the bot as the issuer" do
+      let(:command_issuer) { "test-bot" }
+
+      before do
+        allow(Settings).to receive(:github_credentials).and_return(double(:username => command_issuer))
+      end
+
+      it "does not add invalid labels and comments on error" do
+        expect(issue).to receive(:add_labels).never
+        expect(issue).to receive(:add_comment).with(/^Cannot apply the following label.*not recognized/)
+      end
     end
   end
 


### PR DESCRIPTION
Removes bot thinking it is calling itself when making a comment where it's username could be used when adding a label.

See the following for an example:

  https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/124#issuecomment-783647447