### PR TITLE
[Linter::Haml] Avoid haml-lint STDERR warnings

### DIFF
--- a/lib/linter/base.rb
+++ b/lib/linter/base.rb
@@ -82,10 +82,14 @@ module Linter
       end
     end
 
+    def linter_env
+      []
+    end
+
     def run_linter(dir)
       logger.info("#{log_header} Executing linter...")
       require 'awesome_spawn'
-      result = AwesomeSpawn.run(linter_executable, :params => options, :chdir => dir)
+      result = AwesomeSpawn.run(linter_executable, :params => options, :chdir => dir, :env => linter_env)
       handle_linter_output(result)
     end
 

--- a/lib/linter/haml.rb
+++ b/lib/linter/haml.rb
@@ -10,6 +10,11 @@ module Linter
       'haml-lint *'
     end
 
+    def linter_env
+      parser_stub_path = Rails.root.join("vendor", "stubs").to_s
+      {"RUBYOPT" => "-I #{parser_stub_path}"}
+    end
+
     def options
       {:reporter => 'json'}
     end

--- a/vendor/stubs/parser/current.rb
+++ b/vendor/stubs/parser/current.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Injects a "stub" 'parser/current' file (that should be appended to the Ruby
+# $LOADPATH), which avoids the annoying loading the original, which includes
+# the unskippable warnings like this:
+#
+#     warning: parser/current is loading parser/ruby27, which recognizes
+#     warning: 2.7.2-compliant syntax, but you are running 2.7.1.
+#     warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
+#
+# in STDERR, which are flagged by the bot as errors (when they aren't useful to
+# the end user).
+#
+# This stub will just define the `Parser::CurrentRuby` constant manually using
+# the conventions of the `parser` gem.
+#
+
+require "parser/ruby#{RbConfig::CONFIG["MAJOR"]}#{RbConfig::CONFIG["MINOR"]}"
+
+module Parser
+  CurrentRuby = self.const_get("Ruby#{RbConfig::CONFIG["MAJOR"]}#{RbConfig::CONFIG["MINOR"]}")
+end


### PR DESCRIPTION
Injects a "stub" 'parser/current' file (that should be appended to the Ruby `$LOADPATH`), which avoids the annoying loading the original, which includes the unskippable warnings like this:

```
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.2-compliant syntax, but you are running 2.7.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

in `STDERR`, which are flagged by the bot as errors (when they aren't useful to the end user).

This stub will just define the `Parser::CurrentRuby` constant manually using the conventions of the `parser` gem.

Example in the wild
-------------------

https://github.com/ManageIQ/manageiq-ui-classic/pull/7650#issuecomment-789178507

(copied in case that goes away)

> Checked commit
> https://github.com/NickLaMuro/manageiq-ui-classic/commit/386138b31fbcb061096daa3b88c74188d212bfdb
> with ruby 2.6.3, rubocop 0.82.0, haml-lint 0.35.0, and yamllint 3 files
> checked, 1 offense detected
> 
> **\*\***
> - [ ] :bomb: :boom: :fire: :fire_engine: - Linter/Haml - Linter::Haml STDERR:
> ```
> warning: parser/current is loading parser/ruby26, which recognizes
> warning: 2.6.6-compliant syntax, but you are running 2.6.3.
> warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
> 
> ```
>