### PR TITLE
Smaller docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,24 +15,18 @@ LABEL name="miq-bot" \
       io.k8s.description="ManageIQ Bot is a developer automation tool." \
       io.openshift.tags="ManageIQ,miq-bot"
 
+RUN curl -L -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_x86_64 && \
+    chmod +x /usr/bin/dumb-init
+
 RUN dnf config-manager --setopt=ubi-8-*.exclude=net-snmp*,dracut*,libcom_err*,python3-gobject*,redhat-release* --save && \
-    dnf -y --disableplugin=subscription-manager install \
-      unzip \
-      wget \
+    dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       http://mirror.centos.org/centos/8.3.2011/BaseOS/x86_64/os/Packages/centos-linux-repos-8-2.el8.noarch.rpm \
       http://mirror.centos.org/centos/8.3.2011/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf -y --disableplugin=subscription-manager module enable nodejs:12 && \
     dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
-    dnf -y --disableplugin=subscription-manager upgrade --exclude=filesystem && \
-    dnf clean all
-
-RUN wget https://github.com/ManageIQ/miq_bot/archive/$REF.zip && \
-    unzip $REF.zip -d /opt && \
-    rm -rf $REF.zip && \
-    mv /opt/miq_bot-* $APP_ROOT && \
-    chgrp -R 0 $APP_ROOT && \
-    chmod -R g=u $APP_ROOT
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       @development \
@@ -45,22 +39,31 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
       openssl \
       openssl-devel \
       postgresql-devel \
-      python38 \
       ruby \
       ruby-devel \
       sqlite-devel \
       yamllint && \
-    gem install bundler -v 1.17.3 && \
-    cd $APP_ROOT && \
-    bundle install
+      dnf clean all && \
+      rm -rf /var/cache/dnf
+
+RUN mkdir -p $APP_ROOT && \
+    curl -L https://github.com/ManageIQ/miq_bot/archive/$REF.tar.gz | tar xz -C $APP_ROOT --strip 1 && \
+    chgrp -R 0 $APP_ROOT && \
+    chmod -R g=u $APP_ROOT && \
+    cp $APP_ROOT/container-assets/container_env /usr/local/bin && \
+    cp $APP_ROOT/container-assets/entrypoint /usr/local/bin
 
 WORKDIR $APP_ROOT
 
-RUN curl -L -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_x86_64 && \
-    chmod +x /usr/bin/dumb-init
-
-COPY container-assets/container_env /usr/local/bin
-COPY container-assets/entrypoint /usr/local/bin
+RUN echo "gem: --no-document" > ~/.gemrc && \
+    gem install bundler -v 1.17.3 && \
+    bundle install --jobs=3 --retry=3 && \
+    rm -rf /usr/share/gems/cache/* && \
+    rm -rf /usr/share/gems/gems/rugged-*/vendor && \
+    find /usr/share/gems/gems/ -name *.o -type f -delete && \
+    find /usr/share/gems/gems/ -maxdepth 2 -name docs -type d -exec rm -r {} + && \
+    find /usr/share/gems/gems/ -maxdepth 2 -name spec -type d -exec rm -r {} + && \
+    find /usr/share/gems/gems/ -maxdepth 2 -name test -type d -exec rm -r {} +
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--single-child", "--"]
 


### PR DESCRIPTION
The original image has 4 layers of importance that have been shrunk as
follows (all sizes in MB):

|              | before | after | savings |
| ------------ | ------ | ----- | ------- |
| base         |    201 |   201 |       0 |
| centos setup |     62 |    14 |      48 |
| rpm install  |   ~800 |   747 |      53 |
| gem install  |   ~200 |    98 |     102 |
| total        |  ~1263 | ~1060 |    ~203 |

- Reorganized to put less frequently changing layers first
- Removed dnf upgrade step
- Removed dnf cache in var/cache
- Removed unnecessary gem files such as caches, docs, tests and build
  artifacts like .o files
- Removed wget+unzip in favor of curl from the base image
- Removed python38 in favor of python36 from the base image

@bdunne Please review.