### PR TITLE
[Linter::Base] Fix invalid .linter_env

### DIFF
--- a/lib/linter/base.rb
+++ b/lib/linter/base.rb
@@ -83,7 +83,7 @@ module Linter
     end
 
     def linter_env
-      []
+      {}
     end
 
     def run_linter(dir)

--- a/spec/lib/linter/base_spec.rb
+++ b/spec/lib/linter/base_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Linter::Base do
+  subject { described_class.new(double("branch")) }
+
+  describe "#linter_env" do
+    it "is an empty hash" do
+      expect(subject.send(:linter_env)).to eq({})
+    end
+  end
+end

--- a/spec/lib/linter/haml_spec.rb
+++ b/spec/lib/linter/haml_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Linter::Haml do
+  subject        { described_class.new(double("branch")) }
+  let(:stub_dir) { File.expand_path(File.join(*%w[.. .. .. vendor stubs]), __dir__) }
+
+  describe "#linter_env" do
+    it "is an empty hash" do
+      expect(subject.send(:linter_env)).to eq({"RUBYOPT" => "-I #{stub_dir}"})
+    end
+  end
+end

--- a/spec/lib/linter/rubocop_spec.rb
+++ b/spec/lib/linter/rubocop_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Linter::Rubocop do
+  subject { described_class.new(double("branch")) }
+
+  describe "#linter_env" do
+    it "is an empty hash" do
+      expect(subject.send(:linter_env)).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
The argument for `env` passed to `Open3.capture3` (or `Open3.capture2e`) needs to be a `Hash`, and not an `Array`, other wise the following error is provided:

```
ArgumentError: wrong first argument
/usr/share/ruby/open3.rb:213:in `spawn'
/usr/share/ruby/open3.rb:213:in `popen_run'
/usr/share/ruby/open3.rb:101:in `popen3'
/usr/share/ruby/open3.rb:281:in `capture3'
/usr/share/gems/gems/awesome_spawn-1.5.0/lib/awesome_spawn.rb:127:in `launch'
/usr/share/gems/gems/awesome_spawn-1.5.0/lib/awesome_spawn.rb:80:in `run'
/opt/miq_bot/lib/linter/base.rb:92:in `run_linter'
/opt/miq_bot/lib/linter/base.rb:27:in `block in run'
/usr/share/ruby/tmpdir.rb:93:in `mktmpdir'
/opt/miq_bot/lib/linter/base.rb:18:in `run'
/opt/miq_bot/app/workers/concerns/code_analysis_mixin.rb:24:in `run_all_linters'
/opt/miq_bot/app/workers/concerns/code_analysis_mixin.rb:12:in `merged_linter_results'
/opt/miq_bot/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb:25:in `process_branch'
/opt/miq_bot/app/workers/commit_monitor_handlers/commit_range/rubocop_checker.rb:19:in `perform'
```

Caused by https://github.com/ManageIQ/miq_bot/pull/549

Links
-----

* https://github.com/ManageIQ/miq_bot/pull/549
* Error reported in `gitter`:  https://gitter.im/ManageIQ/miq_bot?at=60775bd1ed4feb3eca8f4976
* Full error stacktrace:  https://gist.github.com/Fryguy/4c577fac9c971a948755268d674f863c