### PR TITLE
[CrossRepoTest] Handle no input

### DIFF
--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -137,7 +137,7 @@ module GithubService
         @repos ||= []
 
         # Expand repo groups (e.g. /providers) in the test repos
-        @test_repos = @test_repos.flat_map { |repo| repo_group?(repo) ? expand_repo_group(repo) : repo }.compact
+        @test_repos = (@test_repos || []).flat_map { |repo| repo_group?(repo) ? expand_repo_group(repo) : repo }.compact
 
         # Add the PR for this comment to the test repos
         @test_repos << "#{issue.repo_name}##{issue.number}"

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       assert_execute(:valid => false)
     end
 
+    context "with no input" do
+      let(:command_value) { "" }
+
+      it "is valid" do
+        assert_execute(:valid => true)
+      end
+    end
+
     describe "with invalid repo names" do
       context "when someone forgets a comma in the test repo list" do
         let(:command_value) { "manageiq-ui-classic manageiq-api" }
@@ -460,6 +468,15 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       it "sets @test_repos and @repos" do
         expect(subject.test_repos).to eq ["ManageIQ/manageiq-api", "ManageIQ/manageiq-ui-classic#1234", issue_identifier].sort
         expect(subject.repos).to      eq ["ManageIQ/manageiq-ui-classic#1234", issue_identifier].sort
+      end
+    end
+
+    context "without any args" do
+      let(:command_value) { "" }
+
+      it "sets @test_repos and @repos" do
+        expect(subject.test_repos).to eq [issue_identifier].sort
+        expect(subject.repos).to      eq [issue_identifier].sort
       end
     end
 


### PR DESCRIPTION
When provided with just the following:

```
@miq-bot cross-repo-test
```

Don't blow up when there are no repos available to call `.flat_map` on.


Example stacktrace
------------------

```
I, [2021-08-10T16:27:10.378096 #6]  INFO -- : Executed GET https://api.github.com/orgs/ManageIQ/members/chessbyte...api calls remaining 2321
2021-08-10T16:27:10.379Z 6 TID-gn94tzmqy GithubNotificationMonitorWorker JID-290814c7bffbae7880d9b0ce ERROR: undefined method `flat_map' for nil:NilClass
2021-08-10T16:27:10.380Z 6 TID-gn94tzmqy GithubNotificationMonitorWorker JID-290814c7bffbae7880d9b0ce ERROR: /opt/miq_bot/lib/github_service/commands/cross_repo_test.rb:140:in `parse_value'
/opt/miq_bot/lib/github_service/commands/cross_repo_test.rb:126:in `_execute'
/opt/miq_bot/lib/github_service/commands/base.rb:33:in `execute!'
/opt/miq_bot/lib/github_service/command_dispatcher.rb:36:in `block in dispatch!'
/opt/miq_bot/lib/github_service/command_dispatcher.rb:26:in `each'
/opt/miq_bot/lib/github_service/command_dispatcher.rb:26:in `dispatch!'
/opt/miq_bot/lib/github_notification_monitor.rb:62:in `process_issue_comment'
/opt/miq_bot/lib/github_notification_monitor.rb:49:in `block in process_issue_thread'
/opt/miq_bot/lib/github_notification_monitor.rb:48:in `each'
/opt/miq_bot/lib/github_notification_monitor.rb:48:in `process_issue_thread'
/opt/miq_bot/lib/github_notification_monitor.rb:39:in `process_notification'
/opt/miq_bot/lib/github_notification_monitor.rb:26:in `block in process_notifications'
/opt/miq_bot/lib/github_notification_monitor.rb:25:in `each'
/opt/miq_bot/lib/github_notification_monitor.rb:25:in `process_notifications'
/opt/miq_bot/app/workers/github_notification_monitor_worker.rb:23:in `process_repo'
/opt/miq_bot/app/workers/github_notification_monitor_worker.rb:19:in `block in process_repos'
...
```


Links
-----

- Error report:  https://gitter.im/ManageIQ/miq_bot?at=6112a820de88340e6d75c249