### PR TITLE
Use a matrix for test-repos not jobs

### DIFF
--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -278,8 +278,8 @@ module GithubService
           "cross-repo" => {
             "uses" => "ManageIQ/manageiq-cross_repo/.github/workflows/manageiq_cross_repo.yaml@master",
             "with" => {
-              "test-repo" => test_repos.inspect,
-              "repos"     => repos.join(",")
+              "test-repos" => test_repos.inspect,
+              "repos"      => repos.join(",")
             }
           }
         }

--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -274,15 +274,15 @@ module GithubService
         raw_yaml = rugged_repo.blob_at(branch_ref.target.oid, ".github/workflows/ci.yaml").content
         content  = YAML.safe_load(raw_yaml)
 
-        content["jobs"] = test_repos.each_with_object({}) do |test_repo, result|
-          result[test_repo] = {
+        content["jobs"] = {
+          "cross-repo" => {
             "uses" => "ManageIQ/manageiq-cross_repo/.github/workflows/manageiq_cross_repo.yaml@master",
             "with" => {
-              "test-repo" => test_repo,
+              "test-repo" => test_repos.inspect,
               "repos"     => repos.join(",")
             }
           }
-        end
+        }
 
         entry = {}
         entry[:path]  = ".github/workflows/ci.yaml"

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -386,14 +386,8 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       github_workflow_yml_content = repo.blob_at(branch.target.oid, ".github/workflows/ci.yaml").content
       content                     = YAML.safe_load(github_workflow_yml_content)
 
-      expect(content["jobs"].count).to eq(2)
-      expect(content["jobs"].keys).to match_array(["foo", "bar"])
-
-      expect(content["jobs"]["foo"]["with"]["test-repo"]).to eq("foo")
-      expect(content["jobs"]["bar"]["with"]["test-repo"]).to eq("bar")
-
-      expect(content["jobs"]["foo"]["with"]["repos"]).to eq("repo1,repo2")
-      expect(content["jobs"]["bar"]["with"]["repos"]).to eq("repo1,repo2")
+      expect(content["jobs"]["cross-repo"]["with"]["test-repo"]).to eq('["foo", "bar"]')
+      expect(content["jobs"]["cross-repo"]["with"]["repos"]).to eq("repo1,repo2")
     end
 
     it "commits the changes" do
@@ -414,8 +408,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       MSG
 
       expect(commit_content).to include "repos: repo1,repo2"
-      expect(commit_content).to include "test-repo: foo"
-      expect(commit_content).to include "test-repo: bar"
+      expect(commit_content).to include "test-repo: '[\"foo\", \"bar\"]'"
     end
 
     it "pushes the changes" do
@@ -436,8 +429,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
         MSG
 
         expect(commit_content).to include "repos: repo1,repo2"
-        expect(commit_content).to include "test-repo: foo"
-        expect(commit_content).to include "test-repo: bar"
+        expect(commit_content).to include "test-repo: '[\"foo\", \"bar\"]'"
       end
     end
 

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -42,7 +42,7 @@ RSpec.shared_context "with stub cross_repo_tests", :with_stub_cross_repo do
         manageiq:
           uses: agrare/manageiq-cross_repo/.github/workflows/manageiq_cross_repo.yaml@github_actions
           with:
-            test-repo: ManageIQ/manageiq@master
+            test-repos: '["ManageIQ/manageiq@master"]'
             repos: ManageIQ/manageiq@master
     YAML
 
@@ -386,7 +386,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       github_workflow_yml_content = repo.blob_at(branch.target.oid, ".github/workflows/ci.yaml").content
       content                     = YAML.safe_load(github_workflow_yml_content)
 
-      expect(content["jobs"]["cross-repo"]["with"]["test-repo"]).to eq('["foo", "bar"]')
+      expect(content["jobs"]["cross-repo"]["with"]["test-repos"]).to eq('["foo", "bar"]')
       expect(content["jobs"]["cross-repo"]["with"]["repos"]).to eq("repo1,repo2")
     end
 
@@ -408,7 +408,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       MSG
 
       expect(commit_content).to include "repos: repo1,repo2"
-      expect(commit_content).to include "test-repo: '[\"foo\", \"bar\"]'"
+      expect(commit_content).to include "test-repos: '[\"foo\", \"bar\"]'"
     end
 
     it "pushes the changes" do
@@ -429,7 +429,7 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
         MSG
 
         expect(commit_content).to include "repos: repo1,repo2"
-        expect(commit_content).to include "test-repo: '[\"foo\", \"bar\"]'"
+        expect(commit_content).to include "test-repos: '[\"foo\", \"bar\"]'"
       end
     end
 


### PR DESCRIPTION
There is a limit of 20 on the number of times other workflows can be referenced in a workflow, so rather than 1 job per repo use a matrix for test-repo