### PR TITLE
Fix YAML replacing on: with true: in github workflow

### DIFF
--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -284,9 +284,12 @@ module GithubService
           }
         }
 
+        updated_yaml = content.to_yaml
+        updated_yaml.gsub!(/^true:/, "on:") # YAML replaces on: with true:
+
         entry = {}
         entry[:path]  = ".github/workflows/ci.yaml"
-        entry[:oid]   = @rugged_repo.write(content.to_yaml, :blob)
+        entry[:oid]   = @rugged_repo.write(updated_yaml, :blob)
         entry[:mode]  = 0o100644
         entry[:mtime] = Time.now.utc
 


### PR DESCRIPTION
```
(byebug) pp github_workflow_yml_content
"---\n" +
"name: Cross Repo Tests\n" +
"on:\n" +
"- pull_request\n" +
"jobs:\n" +
"  cross-repo:\n" +
"    uses: ManageIQ/manageiq-cross_repo/.github/workflows/manageiq_cross_repo.yaml@master\n" +
"    with:\n" +
"      test-repos: '[\"foo\", \"bar\"]'\n" +
"      repos: repo1,repo2\n"
```