### PR TITLE
Add support for the word 'includes' in addition to 'including'

### DIFF
--- a/lib/github_service/commands/cross_repo_test.rb
+++ b/lib/github_service/commands/cross_repo_test.rb
@@ -132,7 +132,7 @@ module GithubService
       def parse_value(value)
         @value = value
 
-        @test_repos, @repos = value.split(/\s+including\s+/)
+        @test_repos, @repos = value.split(/\s+(?:including|includes)\s+/, 2)
                                    .map { |repo_list| repo_list.split(/[, ]+/).map(&:strip) }
         @repos ||= []
 

--- a/spec/lib/github_service/commands/cross_repo_test_spec.rb
+++ b/spec/lib/github_service/commands/cross_repo_test_spec.rb
@@ -147,22 +147,6 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
       end
     end
 
-    describe "with invalid repo names" do
-      context "when there's a typo on the including directive" do
-        let(:command_value) { "manageiq-ui-classic includes manageiq#1234" }
-
-        it "is invalid" do
-          stub_issue_comment(<<~COMMENT)
-            @NickLaMuro 'cross-repo-test(s)' was given invalid repo names and cannot continue
-
-            * `ManageIQ/manageiq-ui-classic includes manageiq#1234`
-          COMMENT
-
-          assert_execute(:valid => false)
-        end
-      end
-    end
-
     describe "with conflicting repo names" do
       context "in the test repo list" do
         let(:command_value) { "manageiq-ui-classic#1234, manageiq-ui-classic#2345" }
@@ -428,6 +412,15 @@ RSpec.describe GithubService::Commands::CrossRepoTest do
 
     context "with 'including' argument" do
       let(:command_value) { "manageiq-ui-classic#1234, manageiq-api including manageiq#2345" }
+
+      it "sets @test_repos and @repos" do
+        expect(subject.test_repos).to eq ["ManageIQ/manageiq-api", "ManageIQ/manageiq-ui-classic#1234", issue_identifier].sort
+        expect(subject.repos).to      eq ["ManageIQ/manageiq#2345", "ManageIQ/manageiq-ui-classic#1234", issue_identifier].sort
+      end
+    end
+
+    context "with 'includes' argument" do
+      let(:command_value) { "manageiq-ui-classic#1234, manageiq-api includes manageiq#2345" }
 
       it "sets @test_repos and @repos" do
         expect(subject.test_repos).to eq ["ManageIQ/manageiq-api", "ManageIQ/manageiq-ui-classic#1234", issue_identifier].sort


### PR DESCRIPTION
@agrare Please review.

This drops the typo spec, which I can't get passing after this change, because there's no way to get a verifiably bad repo name after this point.  Instead it will just create a PR with the "ManageIQ/typo" repo name, which we don't want to handle as per https://github.com/ManageIQ/miq_bot/blob/4e593a7912dbd82740446ce2b6f14caca90fa73c/spec/lib/github_service/commands/cross_repo_test_spec.rb#L329-L336