### PR TITLE
Warn users about merge commits in PRs

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker.rb
@@ -22,6 +22,7 @@ module CommitMonitorHandlers::CommitRange
 
       new_commits.each do |commit_sha, data|
         check_for_usernames_in(commit_sha, data["message"])
+        check_for_merge_commit(commit_sha, data["merge_commit?"])
       end
 
       @offenses
@@ -59,6 +60,14 @@ module CommitMonitorHandlers::CommitRange
         message = "Username `@#{potential_username}` detected in commit message. Consider removing."
         @offenses << OffenseMessage::Entry.new(:low, message, group)
       end
+    end
+
+    def check_for_merge_commit(commit, merge_commit)
+      return unless merge_commit
+
+      group   = ::Branch.github_commit_uri(fq_repo_name, commit)
+      message = "Merge commit #{commit} detected.  Consider rebasing."
+      @offenses << OffenseMessage::Entry.new(:low, message, group)
     end
   end
 end


### PR DESCRIPTION
A common mistake for developers when updating a branch to include changes from master is to create merge commits like https://github.com/ManageIQ/manageiq-providers-ibm_cloud/commit/da298f3fdf3e9243a89dc2ac62784b16b9f205b6 rather than rebasing their commits on top of the master branch.

We recommend setting `git config pull.rebase true` to avoid this but often times new developers miss this.