### PR TITLE
Replace Sidetiq with Sidecloq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,8 @@ gem 'listen'
 
 # Sidekiq specific gems
 gem 'celluloid', '~> 0.17.4', :require => false
+gem 'sidecloq'
 gem 'sidekiq', '~> 5.2.5', '< 5.2.10'
-gem 'sidetiq', '~> 0.7.2' # TODO: No longer maintained!!
 gem 'sinatra', :require => false
 gem 'slim'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (~> 1.8, >= 1.8.0)
     erubi (1.10.0)
+    et-orbi (1.2.7)
+      tzinfo
     ethon (0.15.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
@@ -133,6 +135,9 @@ GEM
     foreman (0.64.0)
       dotenv (~> 0.7.0)
       thor (>= 0.13.6)
+    fugit (1.5.3)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     gh (0.16.0)
       activesupport (~> 5.0)
       addressable (~> 2.4)
@@ -155,7 +160,6 @@ GEM
     highline (1.7.10)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    ice_cube (0.14.0)
     influxdb (0.3.17)
       json
     jquery-rails (4.4.0)
@@ -213,6 +217,7 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
+    raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-protection (2.2.0)
@@ -249,6 +254,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.4)
+    redlock (1.2.2)
+      redis (>= 3.0.0, < 5.0)
     regexp_parser (2.3.1)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -292,6 +299,8 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rufus-scheduler (3.8.2)
+      fugit (~> 1.1, >= 1.1.6)
     rugged (1.5.0.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -307,15 +316,16 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
+    sidecloq (0.4.8)
+      concurrent-ruby
+      redlock (>= 0.2.0, < 2)
+      rufus-scheduler (~> 3.1, >= 3.1.10)
+      sidekiq (>= 3.5.4, < 7)
     sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 4.2)
-    sidetiq (0.7.2)
-      celluloid (>= 0.17.3)
-      ice_cube (~> 0.14.0)
-      sidekiq (>= 4.1.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -406,8 +416,8 @@ DEPENDENCIES
   rspec-rails
   rugged
   sass-rails (~> 5.0.7)
+  sidecloq
   sidekiq (~> 5.2.5, < 5.2.10)
-  sidetiq (~> 0.7.2)
   simplecov (>= 0.21.2)
   sinatra
   slim

--- a/app/workers/batch_job_monitor.rb
+++ b/app/workers/batch_job_monitor.rb
@@ -2,9 +2,6 @@ class BatchJobMonitor
   include Sidekiq::Worker
   sidekiq_options :queue => :miq_bot, :retry => false
 
-  include Sidetiq::Schedulable
-  recurrence { minutely }
-
   include SidekiqWorkerMixin
 
   def perform

--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -4,9 +4,6 @@ class CommitMonitor
   include Sidekiq::Worker
   sidekiq_options :queue => :miq_bot_glacial, :retry => false
 
-  include Sidetiq::Schedulable
-  recurrence { hourly.minute_of_hour(0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55) }
-
   include SidekiqWorkerMixin
 
   # commit handlers expect to handle a specific commit at a time.

--- a/app/workers/github_notification_monitor_worker.rb
+++ b/app/workers/github_notification_monitor_worker.rb
@@ -2,9 +2,6 @@ class GithubNotificationMonitorWorker
   include Sidekiq::Worker
   sidekiq_options :queue => :miq_bot, :retry => false
 
-  include Sidetiq::Schedulable
-  recurrence { minutely }
-
   include SidekiqWorkerMixin
 
   def perform

--- a/app/workers/pull_request_monitor.rb
+++ b/app/workers/pull_request_monitor.rb
@@ -2,9 +2,6 @@ class PullRequestMonitor
   include Sidekiq::Worker
   sidekiq_options :queue => :miq_bot_glacial, :retry => false
 
-  include Sidetiq::Schedulable
-  recurrence { hourly.minute_of_hour(0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55) }
-
   include SidekiqWorkerMixin
 
   def self.enabled_repos

--- a/app/workers/schedulers/stale_issue_marker.rb
+++ b/app/workers/schedulers/stale_issue_marker.rb
@@ -3,9 +3,6 @@ module Schedulers
     include Sidekiq::Worker
     sidekiq_options :queue => :miq_bot_glacial, :retry => false
 
-    include Sidetiq::Schedulable
-    recurrence { weekly.day(:monday) }
-
     include SidekiqWorkerMixin
 
     def perform

--- a/app/workers/travis_build_killer.rb
+++ b/app/workers/travis_build_killer.rb
@@ -2,9 +2,6 @@ class TravisBuildKiller
   include Sidekiq::Worker
   sidekiq_options :queue => :miq_bot, :retry => false
 
-  include Sidetiq::Schedulable
-  recurrence { hourly.minute_of_hour(0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55) }
-
   include SidekiqWorkerMixin
 
   def perform

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 require 'sidekiq/web'
-require 'sidetiq/web'
+require 'sidecloq/web'
 
 MiqBot::Application.routes.draw do
   mount Sidekiq::Web, at: "/sidekiq"

--- a/config/sidecloq.yml
+++ b/config/sidecloq.yml
@@ -1,0 +1,19 @@
+BatchJobMonitor:
+  class: BatchJobMonitor
+  cron: "* * * * *" # minutely
+
+CommitMonitor:
+  class: CommitMonitor
+  cron: "*/5 * * * *" # every 5th minute
+
+GithubNotificationMonitorWorker:
+  class: GithubNotificationMonitorWorker
+  cron: "* * * * *" # minutely
+
+PullRequestMonitor:
+  class: PullRequestMonitor
+  cron: "*/5 * * * *" # every 5th minute
+
+StaleIssueMarker:
+  class: StaleIssueMarker
+  cron: "0 0 * * 1" # midnight every Monday


### PR DESCRIPTION
Closes #282

https://github.com/mattyr/sidecloq

@bdunne @agrare Please review.

I need help verifying this because for some reason locally Rugged is having issues with my private keys...it's an unrelated issue, but it prevents me from testing with "real" repos like the sandbox.

Also, switching to Sidecloq should now unlock our Sidekiq version, since we are no longer dependent on celluloid.  I did not do that in this PR, but will do a couple followup PRs to unlock Sidekiq first to 5.2.latest and then to 6