### PR TITLE
Change merge commit severity to :warning:

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker.rb
@@ -67,7 +67,7 @@ module CommitMonitorHandlers::CommitRange
 
       group   = ::Branch.github_commit_uri(fq_repo_name, commit)
       message = "Merge commit #{commit} detected.  Consider rebasing."
-      @offenses << OffenseMessage::Entry.new(:low, message, group)
+      @offenses << OffenseMessage::Entry.new(:warn, message, group)
     end
   end
 end

--- a/spec/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/github_pr_commenter/commit_metadata_checker_spec.rb
@@ -119,12 +119,14 @@ describe CommitMonitorHandlers::CommitRange::GithubPrCommenter::CommitMetadataCh
       batch_entry.reload
       expect(batch_entry.result.length).to eq(2)
       expect(batch_entry.result.first).to have_attributes(
-        :group   => "https://github.com/#{branch.fq_repo_name}/commit/abcd123",
-        :message => "Merge commit abcd123 detected.  Consider rebasing."
+        :group    => "https://github.com/#{branch.fq_repo_name}/commit/abcd123",
+        :message  => "Merge commit abcd123 detected.  Consider rebasing.",
+        :severity => :warn
       )
       expect(batch_entry.result.second).to have_attributes(
-        :group   => "https://github.com/#{branch.fq_repo_name}/commit/abcd234",
-        :message => "Merge commit abcd234 detected.  Consider rebasing."
+        :group    => "https://github.com/#{branch.fq_repo_name}/commit/abcd234",
+        :message  => "Merge commit abcd234 detected.  Consider rebasing.",
+        :severity => :warn
       )
     end
   end


### PR DESCRIPTION
Change the offense entry severity for a merge commit from :grey_exclamation: to :warning: