### PR TITLE
Be more resilient on missing notification issue numbers

### DIFF
--- a/lib/github_notification_monitor.rb
+++ b/lib/github_notification_monitor.rb
@@ -37,6 +37,8 @@ class GithubNotificationMonitor
     if notification.issue_number.present?
       issue = GithubService.issue(@fq_repo_name, notification.issue_number)
       process_issue_thread(issue)
+    else
+      logger.warn("Skipping processing of notification due to missing issue number: #{notification}")
     end
     notification.mark_thread_as_read
   end

--- a/lib/github_service/notification.rb
+++ b/lib/github_service/notification.rb
@@ -7,7 +7,7 @@ module GithubService
     end
 
     def issue_number
-      subject.url.match(/\/([0-9]+)\Z/).try(:[], 1)
+      subject.url&.match(/\/([0-9]+)\Z/)&.try(:[], 1)
     end
 
     private


### PR DESCRIPTION
@bdunne Please review.  I'm currently seeing the following in production:

```
I, [2023-02-22T18:37:08.761973 #7]  INFO -- : Executed GET https://api.github.com/repos/ManageIQ/manageiq/notifications?all=false&per_page=100...api calls remaining 743
2023-02-22T18:37:08.765Z 7 TID-gok9iyg9n GithubNotificationMonitorWorker JID-839d87e14bc7d073b63b6605 ERROR: undefined method `match' for nil:NilClass
2023-02-22T18:37:08.765Z 7 TID-gok9iyg9n GithubNotificationMonitorWorker JID-839d87e14bc7d073b63b6605 ERROR: /opt/miq_bot/lib/github_service/notification.rb:10:in `issue_number'
/opt/miq_bot/lib/github_notification_monitor.rb:37:in `process_notification'
/opt/miq_bot/lib/github_notification_monitor.rb:26:in `block in process_notifications'
/opt/miq_bot/lib/github_notification_monitor.rb:25:in `each'
/opt/miq_bot/lib/github_notification_monitor.rb:25:in `process_notifications'
/opt/miq_bot/app/workers/github_notification_monitor_worker.rb:23:in `process_repo'
/opt/miq_bot/app/workers/github_notification_monitor_worker.rb:19:in `block in process_repos'
/usr/share/gems/gems/activerecord-5.2.8.1/lib/active_record/relation/delegation.rb:71:in `each'
/usr/share/gems/gems/activerecord-5.2.8.1/lib/active_record/relation/delegation.rb:71:in `each'
/opt/miq_bot/app/workers/github_notification_monitor_worker.rb:19:in `process_repos'
/opt/miq_bot/app/workers/github_notification_monitor_worker.rb:14:in `perform'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:192:in `execute_job'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:165:in `block (2 levels) in process'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:128:in `block in invoke'
/usr/share/gems/gems/sidetiq-0.7.2/lib/sidetiq/middleware/history.rb:18:in `call_with_sidetiq_history'
/usr/share/gems/gems/sidetiq-0.7.2/lib/sidetiq/middleware/history.rb:6:in `call'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:133:in `invoke'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:164:in `block in process'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:137:in `block (6 levels) in dispatch'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/job_retry.rb:109:in `local'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:136:in `block (5 levels) in dispatch'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/rails.rb:43:in `block in call'
/usr/share/gems/gems/activesupport-5.2.8.1/lib/active_support/execution_wrapper.rb:90:in `wrap'
/usr/share/gems/gems/activesupport-5.2.8.1/lib/active_support/reloader.rb:73:in `block in wrap'
/usr/share/gems/gems/activesupport-5.2.8.1/lib/active_support/execution_wrapper.rb:90:in `wrap'
/usr/share/gems/gems/activesupport-5.2.8.1/lib/active_support/reloader.rb:72:in `wrap'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/rails.rb:42:in `call'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:132:in `block (4 levels) in dispatch'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:250:in `stats'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:127:in `block (3 levels) in dispatch'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/job_logger.rb:8:in `call'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:126:in `block (2 levels) in dispatch'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/job_retry.rb:74:in `global'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:125:in `block in dispatch'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/logging.rb:48:in `with_context'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/logging.rb:42:in `with_job_hash_context'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:124:in `dispatch'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:163:in `process'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:83:in `process_one'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:71:in `run'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/util.rb:16:in `watchdog'
/usr/share/gems/gems/sidekiq-5.2.9/lib/sidekiq/util.rb:25:in `block in safe_thread'
```