### PR TITLE
Add irb for rails console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'net-ssh', '~> 7.2.0'
 gem 'awesome_spawn',        '~> 1.6'
 gem 'default_value_for',    '~> 3.4'
 gem 'haml_lint',            '~> 0.51', :require => false
+gem 'irb'
 gem 'manageiq-style',       '>= 1.4',  :require => false
 gem 'more_core_extensions', '~> 4.4',  :require => 'more_core_extensions/all'
 gem 'rugged',                          :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,10 @@ GEM
     hashdiff (1.0.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    io-console (0.7.2)
+    irb (1.14.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     jquery-rails (4.6.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -203,6 +207,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    psych (5.1.2)
+      stringio
     public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
@@ -244,11 +250,15 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
     redis-client (0.22.2)
       connection_pool
     redlock (2.0.6)
       redis-client (>= 0.14.1, < 1.0.0)
     regexp_parser (2.8.2)
+    reline (0.5.9)
+      io-console (~> 0.5)
     rexml (3.3.6)
       strscan
     rspec (3.12.0)
@@ -337,6 +347,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    stringio (3.1.1)
     strscan (3.1.0)
     sync (0.5.0)
     sysexits (1.2.0)
@@ -374,6 +385,7 @@ DEPENDENCIES
   faraday-http-cache (~> 2.0.0)
   foreman
   haml_lint (~> 0.51)
+  irb
   jquery-rails
   listen
   manageiq-style (>= 1.4)


### PR DESCRIPTION
```
sh-5.1# bundle exec rails c
/usr/share/gems/gems/railties-6.1.7.8/lib/rails/commands/console/console_command.rb:3:in `require': cannot load such file -- irb (LoadError) Did you mean?  erb
               drb
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/commands/console/console_command.rb:3:in `<top (required)>'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/command/behavior.rb:44:in `require'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/command/behavior.rb:44:in `block (2 levels) in lookup'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/command/behavior.rb:40:in `each'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/command/behavior.rb:40:in `block in lookup'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/command/behavior.rb:39:in `each'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/command/behavior.rb:39:in `lookup'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/command.rb:74:in `find_by_namespace'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/command.rb:46:in `invoke'
	from /usr/share/gems/gems/railties-6.1.7.8/lib/rails/commands.rb:18:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```
