### PR TITLE
Pin concurrent-ruby to < 1.3.5 for Rails 6.1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ plugin 'bundler-inject'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem 'rails', '~> 6.1.0', '>= 6.1.7.10'
+gem 'concurrent-ruby', '< 1.3.5' # Temporary pin down as concurrent-ruby 1.3.5 breaks Rails 6.1 & 7.0, and rails-core doesn't
+                                 # plan to ship a new 6.1 or 7.0 to fix it. See https://github.com/rails/rails/pull/54264
 
 # Use PostgreSQL as the database for Active Record
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_spawn (~> 1.6)
+  concurrent-ruby (< 1.3.5)
   config
   default_value_for (~> 4.0)
   factory_bot_rails


### PR DESCRIPTION
@bdunne Please review.