### PR TITLE
Add database level uniqueness on branch records

### DIFF
--- a/db/migrate/20250305205548_add_uniqueness_constraint_on_branches.rb
+++ b/db/migrate/20250305205548_add_uniqueness_constraint_on_branches.rb
@@ -1,0 +1,5 @@
+class AddUniquenessConstraintOnBranches < ActiveRecord::Migration[6.1]
+  def up
+    add_index(:branches, [:name, :repo_id], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2017_10_06_050814) do
+ActiveRecord::Schema.define(version: 2025_03_05_205548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2017_10_06_050814) do
     t.string "merge_target"
     t.string "pr_title"
     t.integer "linter_offense_count"
+    t.index ["name", "repo_id"], name: "index_branches_on_name_and_repo_id", unique: true
   end
 
   create_table "repos", id: :serial, force: :cascade do |t|

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -16,6 +16,21 @@ describe Branch do
     )
   end
 
+  context "database uniqueness on repo and name" do
+    let(:branch_model_stub) { Class.new(ActiveRecord::Base) { self.table_name = "branches" } }
+    let(:duplicate_branch)  { branch_model_stub.new(branch.slice(:name, :repo_id, :last_commit, :commit_uri)) }
+
+    it "with the same data fails" do
+      branch
+      expect { duplicate_branch.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "with a different name succeeds" do
+      branch
+      expect { duplicate_branch.tap { |b| b.name += "different" }.save! }.not_to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
   context ".github_commit_uri" do
     it "(repo_name)" do
       actual = described_class.github_commit_uri("ManageIQ/sandbox")


### PR DESCRIPTION
Somehow we have duplicate (2-3) branch records being created at the same time (within 1 second) in the prod database and the rails validation is not good enough.  Let the database handle the uniqueness to prevent this from happening in the future.
