### PR TITLE
Check version format during release

### DIFF
--- a/lib/tasks/production.rake
+++ b/lib/tasks/production.rake
@@ -146,7 +146,13 @@ namespace :production do
       $stderr.puts "ERROR: must specify the version number to deploy"
       exit 1
     end
+
     version = "v#{version}" unless version.start_with?("v")
+    unless version.match?(/^v\d+\.\d+\.\d+$/)
+      $stderr.puts "ERROR: version is not in the expected format"
+      exit 1
+    end
+
     version
   end
 


### PR DESCRIPTION
@bdunne Please review.  I accidentally did the wrong thing, passing the remote first in the parameters, and it went ahead and created a vupstream tag and "release".  This prevents that kind of mistake moving forward.