### PR TITLE
Add support for a VERSION file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN mkdir -p $APP_ROOT && \
     chgrp -R 0 $APP_ROOT && \
     chmod -R g=u $APP_ROOT && \
     cp $APP_ROOT/container-assets/container_env /usr/local/bin && \
-    cp $APP_ROOT/container-assets/entrypoint /usr/local/bin
+    cp $APP_ROOT/container-assets/entrypoint /usr/local/bin && \
+    echo "$REF" > $APP_ROOT/VERSION
 
 WORKDIR $APP_ROOT
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,13 @@ module MiqBot
   end
 
   def self.version
-    @version ||= `GIT_DIR=#{Rails.root.join('.git')} git describe --tags`.chomp
+    @version ||=
+      if Rails.root.join('.git').exist?
+        `GIT_DIR=#{Rails.root.join('.git')} git describe --tags`.chomp
+      elsif Rails.root.join("VERSION").exist?
+        Rails.root.join("VERSION").read.chomp
+      else
+        ""
+      end
   end
 end

--- a/spec/miq_bot_spec.rb
+++ b/spec/miq_bot_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe MiqBot do
+  describe ".version" do
+    before { MiqBot.instance_variable_set(:@version, nil)  }
+    after  { MiqBot.instance_variable_set(:@version, nil)  }
+
+    it "with git dir present" do
+      expect(described_class).to receive(:`).with("GIT_DIR=#{File.expand_path("..", __dir__)}/.git git describe --tags").and_return("v0.21.2-91-g6800275\n")
+
+      expect(described_class.version).to eq("v0.21.2-91-g6800275")
+    end
+
+    context "with git dir not present" do
+      let!(:tmpdir) do
+        Pathname.new(Dir.mktmpdir("fake_rails_root")).tap do |tmpdir|
+          expect(Rails).to receive(:root).at_least(:once).and_return(tmpdir)
+        end
+      end
+      after { FileUtils.rm_rf(tmpdir) }
+
+      context "and VERSION file present" do
+        before { tmpdir.join("VERSION").write("v0.21.2-91-g6800275\n") }
+
+        it "returns the content of the VERSION file" do
+          expect(described_class.version).to eq("v0.21.2-91-g6800275")
+        end
+      end
+
+      context "and VERSION file not present" do
+        it "returns nothing" do
+          expect(described_class.version).to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@bdunne Please review. In prod, since we pull the tarball, there is no git dir, and thus no version output. This creates a VERSION file instead, which can be used to display the current version in prod.