### PR TITLE
Don't include newer openssl packages from CentOS Stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN ARCH=$(uname -m) && \
       http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-26.el9.noarch.rpm && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf config-manager --save --setopt=appstream.exclude=openssl* --setopt=baseos.exclude=openssl* && \
     dnf -y --disableplugin=subscription-manager module enable nodejs:18 && \
     dnf -y module enable ruby:3.1 && \
     dnf -y update && \


### PR DESCRIPTION
The CentOS Stream packages conflict with openssl-fips-provider from UBI