### PR TITLE
Switch to newer openssl for rpm, ruby and nodejs from CentOS Stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN ARCH=$(uname -m) && \
       http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-26.el9.noarch.rpm && \
     dnf -y install \
       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    dnf config-manager --save --setopt=appstream.exclude=openssl* --setopt=baseos.exclude=openssl* && \
+    dnf -y --disablerepo=ubi-9-baseos-rpms swap openssl-fips-provider openssl-libs && \
     dnf -y --disableplugin=subscription-manager module enable nodejs:18 && \
     dnf -y module enable ruby:3.1 && \
     dnf -y update && \


### PR DESCRIPTION
Error:
```
Error: 
 Problem 1: package rpm-libs-4.16.1.3-38.el9.x86_64 from baseos requires libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed
  - cannot install the best update candidate for package rpm-libs-4.16.1.3-37.el9.x86_64
  - package openssl-libs-1:3.5.0-1.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-2.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-3.el9.x86_64 from baseos is filtered out by exclude filtering
 Problem 2: package python3-rpm-4.16.1.3-38.el9.x86_64 from baseos requires rpm-libs(x86-64) = 4.16.1.3-38.el9, but none of the providers can be installed
  - package rpm-libs-4.16.1.3-38.el9.x86_64 from baseos requires libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed
  - cannot install the best update candidate for package python3-rpm-4.16.1.3-37.el9.x86_64
  - package openssl-libs-1:3.5.0-1.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-2.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-3.el9.x86_64 from baseos is filtered out by exclude filtering
 Problem 3: package rpm-build-libs-4.16.1.3-38.el9.x86_64 from baseos requires rpm-libs(x86-64) = 4.16.1.3-38.el9, but none of the providers can be installed
  - package rpm-libs-4.16.1.3-38.el9.x86_64 from baseos requires libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed
  - cannot install the best update candidate for package rpm-build-libs-4.16.1.3-37.el9.x86_64
  - package openssl-libs-1:3.5.0-1.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-2.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-3.el9.x86_64 from baseos is filtered out by exclude filtering
 Problem 4: package rpm-sign-libs-4.16.1.3-38.el9.x86_64 from baseos requires rpm-libs(x86-64) = 4.16.1.3-38.el9, but none of the providers can be installed
  - package rpm-libs-4.16.1.3-38.el9.x86_64 from baseos requires libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed
  - cannot install the best update candidate for package rpm-sign-libs-4.16.1.3-37.el9.x86_64
  - package openssl-libs-1:3.5.0-1.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-2.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-3.el9.x86_64 from baseos is filtered out by exclude filtering
 Problem 5: package rpm-4.16.1.3-38.el9.x86_64 from baseos requires librpm.so.9()(64bit), but none of the providers can be installed
  - package rpm-4.16.1.3-38.el9.x86_64 from baseos requires librpmio.so.9()(64bit), but none of the providers can be installed
  - package rpm-libs-4.16.1.3-37.el9.x86_64 from @System requires rpm = 4.16.1.3-37.el9, but none of the providers can be installed
  - package rpm-libs-4.16.1.3-37.el9.x86_64 from baseos requires rpm = 4.16.1.3-37.el9, but none of the providers can be installed
  - package rpm-libs-4.16.1.3-37.el9.x86_64 from ubi-9-baseos-rpms requires rpm = 4.16.1.3-37.el9, but none of the providers can be installed
  - package rpm-libs-4.16.1.3-32.el9.x86_64 from baseos requires rpm = 4.16.1.3-32.el9, but none of the providers can be installed
  - package rpm-libs-4.16.1.3-34.el9.x86_64 from baseos requires rpm = 4.16.1.3-34.el9, but none of the providers can be installed
  - package rpm-libs-4.16.1.3-36.el9.x86_64 from baseos requires rpm = 4.16.1.3-36.el9, but none of the providers can be installed
  - cannot install both rpm-4.16.1.3-38.el9.x86_64 from baseos and rpm-4.16.1.3-37.el9.x86_64 from @System
  - cannot install both rpm-4.16.1.3-38.el9.x86_64 from baseos and rpm-4.16.1.3-32.el9.x86_64 from baseos
  - cannot install both rpm-4.16.1.3-38.el9.x86_64 from baseos and rpm-4.16.1.3-34.el9.x86_64 from baseos
  - cannot install both rpm-4.16.1.3-38.el9.x86_64 from baseos and rpm-4.16.1.3-36.el9.x86_64 from baseos
  - cannot install both rpm-4.16.1.3-38.el9.x86_64 from baseos and rpm-4.16.1.3-37.el9.x86_64 from baseos
  - cannot install both rpm-4.16.1.3-37.el9.x86_64 from ubi-9-baseos-rpms and rpm-4.16.1.3-38.el9.x86_64 from baseos
  - package rpm-libs-4.16.1.3-38.el9.x86_64 from baseos requires libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed
  - cannot install the best update candidate for package rpm-4.16.1.3-37.el9.x86_64
  - package openssl-libs-1:3.5.0-1.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-2.el9.x86_64 from baseos is filtered out by exclude filtering
  - package openssl-libs-1:3.5.0-3.el9.x86_64 from baseos is filtered out by exclude filtering
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
Error: building at STEP "RUN ARCH=$(uname -m) &&     dnf -y --setopt=protected_packages= remove redhat-release &&     dnf -y install       http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-release-9.0-26.el9.noarch.rpm       http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-26.el9.noarch.rpm       http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-26.el9.noarch.rpm &&     dnf -y install       https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&     dnf config-manager --save --setopt=appstream.exclude=openssl* --setopt=baseos.exclude=openssl* &&     dnf -y --disableplugin=subscription-manager module enable nodejs:18 &&     dnf -y module enable ruby:3.1 &&     dnf -y update &&     dnf clean all &&     rm -rf /var/cache/dnf": while running runtime: exit status 1
```