### PR TITLE
Drop MAINTAINER docker instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
-MAINTAINER ManageIQ https://manageiq.org
 
 ARG REF=master
 


### PR DESCRIPTION
We already have labels for vendor and url

@bdunne Please review