### PR TITLE
Fix unique worker check

### DIFF
--- a/app/workers/concerns/sidekiq_worker_mixin.rb
+++ b/app/workers/concerns/sidekiq_worker_mixin.rb
@@ -71,11 +71,11 @@ module SidekiqWorkerMixin
     def workers
       queue = sidekiq_queue.to_s
 
-      workers = Sidekiq::Workers.new
+      workers = Sidekiq::WorkSet.new
       workers = workers.select do |_processid, _threadid, work|
-        work["queue"] == queue && work.fetch_path("payload", "class") == name
+        work.job.queue == queue && work.job.klass == name
       end
-      workers.sort_by! { |_processid, _threadid, work| work.fetch_path("payload", "enqueued_at") }
+      workers.sort_by! { |_processid, _threadid, work| work.job.enqueued_at }
 
       workers
     end
@@ -91,6 +91,6 @@ module SidekiqWorkerMixin
 
   def first_unique_worker?(workers = nil)
     _processid, _threadid, work = (workers || self.workers).first
-    work.nil? || work.fetch_path("payload", "jid") == jid
+    work.nil? || work.job.jid == jid
   end
 end


### PR DESCRIPTION
An update to Sidekiq changed this logic, where checking the `class` would return nil. This caused all workers to think they were the first one, and thus we had workers that should run as a singleton running multiple instances.

@bdunne Please review.

This code is kind of hard to test as it relies on Sidekiq::WorkSet (formerly Sidekiq::Workers) returning some real data, so I will test in a folllow up if I can. For now I verified this code kind of works in rails console in prod.