### PR TITLE
Prevent CPU saturation and allow Sidekiq to work in tight loops

### DIFF
--- a/app/workers/commit_monitor.rb
+++ b/app/workers/commit_monitor.rb
@@ -47,7 +47,10 @@ class CommitMonitor
   end
 
   def process_repos
-    enabled_repos.includes(:branches).each { |repo| process_repo(repo) }
+    enabled_repos.includes(:branches).each do |repo|
+      process_repo(repo)
+      Thread.pass # Allow Sidekiq to do other work (see https://github.com/sidekiq/sidekiq/discussions/5039)
+    end
   end
 
   private

--- a/app/workers/github_notification_monitor_worker.rb
+++ b/app/workers/github_notification_monitor_worker.rb
@@ -17,6 +17,7 @@ class GithubNotificationMonitorWorker
     notifications_by_repo_name.select! { |repo_name, _notifications| enabled_repo_names.include?(repo_name) }
     notifications_by_repo_name.each do |repo_name, notifications|
       process_repo(repo_name, notifications)
+      Thread.pass
     end
   end
 

--- a/app/workers/pull_request_monitor.rb
+++ b/app/workers/pull_request_monitor.rb
@@ -31,7 +31,10 @@ class PullRequestMonitor
   end
 
   def process_repos
-    enabled_repos.each { |repo| process_repo(repo) }
+    enabled_repos.each do |repo|
+      process_repo(repo)
+      Thread.pass # Allow Sidekiq to do other work (see https://github.com/sidekiq/sidekiq/discussions/5039)
+    end
   end
 
   def process_repo(repo)


### PR DESCRIPTION
Seeing warnings in the glacial logs of the following:

```
WARN: Your Redis network connection is performing extremely poorly.
Last RTT readings were [935714, 379572, 148173, 74808, 143042], ideally these should be < 1000.
Ensure Redis is running in the same AZ or datacenter as Sidekiq.
If these values are close to 100,000, that means your Sidekiq process may be
CPU-saturated; reduce your concurrency and/or see https://github.com/sidekiq/sidekiq/discussions/5039
```

The linked discussion mentions using Thread.pass in any loops to give Sidekiq a chance to do some maintenance work.

This commit adds Thread.pass to some of the longer lasting loops to see if it can prevent the CPU saturation being seen.

@bdunne Please review.