### PR TITLE
Reduce API calls by querying all notifications and not per-repo notifications

### DIFF
--- a/lib/github_notification_monitor.rb
+++ b/lib/github_notification_monitor.rb
@@ -16,13 +16,14 @@ class GithubNotificationMonitor
     "set_milestone"   => :set_milestone
   ).freeze
 
-  def initialize(fq_repo_name)
+  def initialize(fq_repo_name, notifications)
     @username = Settings.github_credentials.username
     @fq_repo_name = fq_repo_name
+    @notifications = notifications
   end
 
   def process_notifications
-    GithubService.repository_notifications(@fq_repo_name, "all" => false).each do |notification|
+    @notifications.each do |notification|
       process_notification(notification)
     end
   end

--- a/lib/github_service.rb
+++ b/lib/github_service.rb
@@ -56,8 +56,8 @@ module GithubService
       end
     end
 
-    def repository_notifications(*args)
-      service.repository_notifications(*args).map do |notification|
+    def notifications(*args)
+      service.notifications(*args).map do |notification|
         Notification.new(notification)
       end
     end

--- a/spec/lib/github_notification_monitor_spec.rb
+++ b/spec/lib/github_notification_monitor_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe GithubNotificationMonitor do
-  subject(:notification_monitor) { described_class.new(fq_repo_name) }
+  subject(:notification_monitor) { described_class.new(fq_repo_name, [notification]) }
 
   let(:notification) { double('notification', :issue_number => issue.number) }
   let(:issue) do
@@ -40,8 +40,6 @@ RSpec.describe GithubNotificationMonitor do
         .with(described_class::GITHUB_NOTIFICATION_MONITOR_YAML_FILE, {:permitted_classes=>[Date, Time]}) do
         { "timestamps" => { fq_repo_name => { issue.number => 10.minutes.ago } } }
       end
-      allow(GithubService).to receive(:repository_notifications)
-        .with(fq_repo_name, a_hash_including("all" => false)).and_return([notification])
       allow(GithubService).to receive(:issue)
         .with(fq_repo_name, notification.issue_number).and_return(issue)
       allow(GithubService).to receive(:issue_comments)

--- a/spec/workers/github_notification_monitor_worker_spec.rb
+++ b/spec/workers/github_notification_monitor_worker_spec.rb
@@ -2,44 +2,51 @@ RSpec.describe GithubNotificationMonitorWorker do
   before  { stub_sidekiq_logger(described_class) }
   subject { described_class.new }
 
-  def stub_github_notification_monitors(*org_repo_pairs)
-    repo_names = org_repo_pairs.collect { |pair| pair.join("/") }
+  def stub_github_notification_monitors(repo_names)
     stub_settings(:github_notification_monitor => {:repo_names => repo_names})
 
-    org_repo_pairs.collect.with_index do |(org, repo), i|
-      fq_repo_name = "#{org}/#{repo}"
-      create(:repo, :name => fq_repo_name)
+    notifications = []
 
-      double("github notification monitor #{i}").tap do |notification_monitor|
-        allow(GithubNotificationMonitor).to receive(:new).with(fq_repo_name).and_return(notification_monitor)
+    monitors = Array(repo_names).map do |repo_name|
+      create(:repo, :name => repo_name)
+
+      notification = double("notification for #{repo_name}", :repository => double("repo", :full_name => repo_name))
+      notifications << notification
+
+      double("github notification monitor for #{repo_name}").tap do |notification_monitor|
+        expect(GithubNotificationMonitor).to receive(:new).with(repo_name, [notification]).and_return(notification_monitor)
       end
     end
+
+    expect(GithubService).to receive(:notifications).with("all" => false).and_return(notifications)
+
+    monitors
   end
 
   describe "#perform" do
     it "skips if the list of repo names is not provided" do
-      stub_settings(:github_notification_monitor => {:repo_names => nil})
+      stub_github_notification_monitors(nil)
 
       expect(GithubNotificationMonitor).to_not receive(:new)
       subject.perform
     end
 
     it "skips if the list of repo names is empty" do
-      stub_settings(:github_notification_monitor => {:repo_names => []})
+      stub_github_notification_monitors([])
 
       expect(GithubNotificationMonitor).to_not receive(:new)
       subject.perform
     end
 
     it "gets notifications from a notification monitor" do
-      nm = stub_github_notification_monitors(["SomeOrg", "some_repo"]).first
+      nm = stub_github_notification_monitors(["SomeOrg/some_repo"]).first
 
       expect(nm).to receive(:process_notifications).once
       subject.perform
     end
 
     it "gets notifications from multiple notification monitors" do
-      nm1, nm2 = stub_github_notification_monitors(["SomeOrg", "some_repo1"], ["SomeOrg", "some_repo2"])
+      nm1, nm2 = stub_github_notification_monitors(["SomeOrg/some_repo1", "SomeOrg/some_repo2"])
 
       expect(nm1).to receive(:process_notifications).once
       expect(nm2).to receive(:process_notifications).once
@@ -47,7 +54,7 @@ RSpec.describe GithubNotificationMonitorWorker do
     end
 
     it "handles errors raised by a notification monitor" do
-      nm1, nm2 = stub_github_notification_monitors(["SomeOrg", "some_repo1"], ["SomeOrg", "some_repo2"])
+      nm1, nm2 = stub_github_notification_monitors(["SomeOrg/some_repo1", "SomeOrg/some_repo2"])
 
       expect(nm1).to receive(:process_notifications).once.and_raise("boom")
       expect(nm2).to receive(:process_notifications).once


### PR DESCRIPTION
With 80 repos being watched by miq-bot, running once per minute, this reduces the API calls from 4800/hr to ~60/hr.

@bdunne Please review.