### PR TITLE
Split out the container build into a parallel job in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,5 +52,9 @@ jobs:
       run: bin/setup
     - name: Run tests
       run: bundle exec rake
+  ci-container-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
     - name: Test Container Build
       run: docker build .


### PR DESCRIPTION
The container build doesn't really depend on anything in the spec tests, so move it out to a parallel job in CI to save time.