### PR TITLE
Fix issue where mergeability checker would not run on PR updates

### DIFF
--- a/spec/workers/commit_monitor_handlers/commit_range/branch_mergeability_checker_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/branch_mergeability_checker_spec.rb
@@ -1,12 +1,20 @@
 describe CommitMonitorHandlers::CommitRange::BranchMergeabilityChecker do
   let!(:branch)     { create(:branch) }
   let!(:pr_branch)  { create(:pr_branch, :repo => branch.repo, :merge_target => branch.name) }
-  let!(:pr_branch2) { create(:pr_branch, :repo => branch.repo) }
+  let!(:pr_branch2) { create(:pr_branch, :repo => branch.repo, :merge_target => "some-other-branch") }
+  let!(:pr_branch3) { create(:pr_branch, :repo => branch.repo, :merge_target => branch.name) }
 
   before { stub_sidekiq_logger }
 
+  it "runs PrMergeabilityChecker synchronously when a PR branch is updated" do
+    expect(PrMergeabilityChecker).to receive(:perform_sync).once.with(pr_branch.id)
+
+    described_class.new.perform(pr_branch.id, ["abcde123"])
+  end
+
   it "queues up PrMergeabilityChecker for PRs targeting this branch" do
     expect(PrMergeabilityChecker).to receive(:perform_async).once.with(pr_branch.id)
+    expect(PrMergeabilityChecker).to receive(:perform_async).once.with(pr_branch3.id)
 
     described_class.new.perform(branch.id, ["abcde123"])
   end


### PR DESCRIPTION
Mergeability checker was changed in #403 to trigger when a target branch updates, which in turn would check the mergeability of all PR targeting that branch. This avoided checking PRs unnecessarily. However, that caused it to now miss any PRs that were updated directly with new commits. In a busy repo where the master branch is updated fairly frequently, that push to master would trigger the check on the PR, and it would appear like the mergeability checker would "sometimes work".

This commit changes the BranchMergeabilityChecker to do a synchronous check on PRs, while keeping the async check of PRs to target branches.

Fixes #438

@agrare Please review,