### PR TITLE
Use the Sidekiq logger for ratelimit logging

### DIFF
--- a/lib/github_service/response/ratelimit_logger.rb
+++ b/lib/github_service/response/ratelimit_logger.rb
@@ -7,7 +7,7 @@ module GithubService
 
       def initialize(app, logger = nil)
         super(app)
-        @logger = logger || begin
+        @logger = logger || Sidekiq.logger || begin
           require 'logger'
           ::Logger.new(STDOUT)
         end


### PR DESCRIPTION
This makes the logs line up nicer and you also get the benefit of knowing which job is mkaing the API call.

Before:

```
2026-02-06T23:24:00.226Z pid=43037 tid=tg9 class=GithubNotificationMonitorWorker jid=b08fb00ea9be64bfaf906dbb INFO: start
I, [2026-02-06T18:24:00.726210 #43037]  INFO -- : Executed GET https://api.github.com/notifications?all=false&per_page=100...api calls remaining 4999
2026-02-06T23:24:00.726Z pid=43037 tid=tg9 class=GithubNotificationMonitorWorker jid=b08fb00ea9be64bfaf906dbb elapsed=0.5 INFO: done
```

After:

```
2026-02-06T23:18:00.116Z pid=40667 tid=vnj class=GithubNotificationMonitorWorker jid=790f171759ee49c5f155e5a5 INFO: start
2026-02-06T23:18:00.372Z pid=40667 tid=vnj class=GithubNotificationMonitorWorker jid=790f171759ee49c5f155e5a5 INFO: Executed GET https://api.github.com/notifications?all=false&per_page=100...api calls remaining 4975
2026-02-06T23:18:00.372Z pid=40667 tid=vnj class=GithubNotificationMonitorWorker jid=790f171759ee49c5f155e5a5 elapsed=0.257 INFO: done
```

@jrafanie Please review.