### PR TITLE
Unremovable/unassignable labels regex

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -137,41 +137,4 @@ labels:
     radjabov/yes: radjabov/yes?
     spassky/yes: spassky/yes?
   :unremovable:
-  - fine/backported
-  - fine/no
-  - gaprindashvili/backported
-  - gaprindashvili/no
-  - hammer/backported
-  - hammer/no
-  - ivanchuk/backported
-  - ivanchuk/no
-  - jansa/backported
-  - jansa/no
-  - jansa/yes
-  - kasparov/backported
-  - kasparov/no
-  - kasparov/yes
-  - lasker/backported
-  - lasker/no
-  - lasker/yes
-  - morphy/backported
-  - morphy/no
-  - morphy/yes
-  - najdorf/backported
-  - najdorf/no
-  - najdorf/yes
-  - oparin/backported
-  - oparin/no
-  - oparin/yes
-  - petrosian/backported
-  - petrosian/no
-  - petrosian/yes
-  - quinteros/backported
-  - quinteros/no
-  - quinteros/yes
-  - radjabov/backported
-  - radjabov/no
-  - radjabov/yes
-  - spassky/backported
-  - spassky/no
-  - spassky/yes
+  - !ruby/regexp /\/(?:backported|no|yes)\z/

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -126,15 +126,7 @@ stale_issue_marker:
 
 labels:
   :unassignable:
-    jansa/yes: jansa/yes?
-    kasparov/yes: kasparov/yes?
-    lasker/yes: lasker/yes?
-    morphy/yes: morphy/yes?
-    najdorf/yes: najdorf/yes?
-    oparin/yes: oparin/yes?
-    petrosian/yes: petrosian/yes?
-    quinteros/yes: quinteros/yes?
-    radjabov/yes: radjabov/yes?
-    spassky/yes: spassky/yes?
+  - pattern: !ruby/regexp /\A(.+)\/yes\z/
+    replacement: '\1/yes?'
   :unremovable:
   - !ruby/regexp /\/(?:backported|no|yes)\z/

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,9 @@
 :labels:
   :unassignable:
-    jansa/yes: jansa/yes?
+  - pattern: jansa/yes
+    replacement: jansa/yes?
+  - pattern: !ruby/regexp /\A(.+)\/foo\z/
+    replacement: '\1/foo?'
   :unremovable:
   - jansa/no
   - jansa/yes

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -4,6 +4,7 @@
   :unremovable:
   - jansa/no
   - jansa/yes
+  - !ruby/regexp /\/foo\z/
 # In test, turn everything on by default
 #   NOTE: Using empty string is a HACK until we can get
 #   https://github.com/danielsdeleo/deep_merge/pull/33 released via the

--- a/lib/github_service/commands/add_label.rb
+++ b/lib/github_service/commands/add_label.rb
@@ -4,7 +4,7 @@ module GithubService
       include IsTeamMember
 
       def unassignable_labels
-        @unassignable_labels ||= Settings.labels.unassignable.to_h.stringify_keys
+        @unassignable_labels ||= Array(Settings.labels.unassignable)
       end
 
       private
@@ -57,8 +57,25 @@ module GithubService
 
       def handle_unassignable_labels(valid_labels)
         valid_labels.map! do |label|
-          unassignable_labels.key?(label) ? unassignable_labels[label] : label
+          find_unassignable_replacement(label) || label
         end
+      end
+
+      def find_unassignable_replacement(label)
+        unassignable_labels.each do |rule|
+          pattern = rule["pattern"]
+          replacement = rule["replacement"]
+
+          case pattern
+          when Regexp
+            return label.sub(pattern, replacement) if label.match?(pattern)
+          when String
+            return replacement if pattern == label
+          else
+            raise "Invalid pattern in unassignable setting: #{pattern.inspect}"
+          end
+        end
+        nil
       end
 
       def invalid_label_message(issuer, invalid_labels)

--- a/lib/github_service/commands/remove_label.rb
+++ b/lib/github_service/commands/remove_label.rb
@@ -38,8 +38,14 @@ module GithubService
 
       def process_extracted_labels(issuer, valid_labels, _invalid_labels, unremovable)
         unless triage_member?(issuer)
-          valid_labels.each { |label| unremovable << label if Settings.labels.unremovable.include?(label) }
+          valid_labels.each { |label| unremovable << label if unremovable_label?(label) }
           unremovable.each  { |label| valid_labels.delete(label) }
+        end
+      end
+
+      def unremovable_label?(label)
+        Array(Settings.labels.unremovable).any? do |unremovable_label_check|
+          unremovable_label_check.kind_of?(Regexp) ? label.match?(unremovable_label_check) : unremovable_label_check == label
         end
       end
 

--- a/spec/lib/github_service/commands/add_label_spec.rb
+++ b/spec/lib/github_service/commands/add_label_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe GithubService::Commands::AddLabel do
     end
   end
 
-  context "un-assignable labels" do
+  context "unassignable labels" do
     let(:command_value)  { "jansa/yes" }
     let(:triage_members) { [{"login" => "Fryguy"}] }
 
@@ -103,14 +103,14 @@ RSpec.describe GithubService::Commands::AddLabel do
                               :response_body => miq_teams.to_json
       github_service_add_stub :url           => "/teams/3456/members?per_page=100",
                               :response_body => triage_members.to_json
+
+      # Assume all labels are valid
+      allow(GithubService).to receive(:valid_label?).and_return(true)
+      # Assume all labels are not currently applied
+      allow(issue).to receive(:applied_label?).and_return(false)
     end
 
     context "without a triage team" do
-      before do
-        allow(issue).to receive(:applied_label?).with("jansa/yes?").and_return(false)
-        allow(GithubService).to receive(:valid_label?).with("foo/bar", command_value).and_return(true)
-      end
-
       it "corrects the label to 'jansa/yes?'" do
         expect(issue).to receive(:add_labels).with(["jansa/yes?"])
         expect(issue).not_to receive(:add_comment)
@@ -119,8 +119,6 @@ RSpec.describe GithubService::Commands::AddLabel do
 
     context "with a non-triage user" do
       before do
-        allow(issue).to receive(:applied_label?).with("jansa/yes?").and_return(false)
-        allow(GithubService).to receive(:valid_label?).with("foo/bar", command_value).and_return(true)
         stub_settings(:member_organization_name => "ManageIQ", :triage_team_name => "my-triage-team")
       end
 
@@ -139,13 +137,20 @@ RSpec.describe GithubService::Commands::AddLabel do
       end
 
       before do
-        allow(issue).to receive(:applied_label?).with("jansa/yes").and_return(false)
-        allow(GithubService).to receive(:valid_label?).with("foo/bar", command_value).and_return(true)
         stub_settings(:member_organization_name => "ManageIQ", :triage_team_name => "my-triage-team")
       end
 
       it "applies the original label" do
         expect(issue).to receive(:add_labels).with(["jansa/yes"])
+        expect(issue).not_to receive(:add_comment)
+      end
+    end
+
+    context "with string and regex patterns in unassignable labels" do
+      let(:command_value) { "jansa/yes, test/foo" }
+
+      it "replaces labels with their substitution patterns" do
+        expect(issue).to receive(:add_labels).with(["jansa/yes?", "test/foo?"])
         expect(issue).not_to receive(:add_comment)
       end
     end

--- a/spec/lib/github_service/commands/remove_label_spec.rb
+++ b/spec/lib/github_service/commands/remove_label_spec.rb
@@ -66,15 +66,11 @@ RSpec.describe GithubService::Commands::RemoveLabel do
                                 :response_body => miq_teams.to_json
         github_service_add_stub :url           => "/teams/3456/members?per_page=100",
                                 :response_body => triage_members.to_json
-      end
 
-      before do
-        %w[wontfix jansa/no jansa/yes jansa/yes?].each do |label|
-          allow(GithubService).to receive(:valid_label?).with("foo/bar", label).and_return(true)
-        end
-
-        expect(issue).to receive(:applied_label?).with("wontfix").and_return(true)
-        expect(issue).to receive(:applied_label?).with("jansa/yes?").and_return(true)
+        # Assume all labels are valid
+        allow(GithubService).to receive(:valid_label?).and_return(true)
+        # Assume all labels are currently applied
+        allow(issue).to receive(:applied_label?).and_return(true)
       end
 
       context "without a triage team" do
@@ -121,9 +117,6 @@ RSpec.describe GithubService::Commands::RemoveLabel do
         end
 
         before do
-          expect(issue).to receive(:applied_label?).with("jansa/no").and_return(true)
-          expect(issue).to receive(:applied_label?).with("jansa/yes").and_return(true)
-
           stub_settings(:member_organization_name => "ManageIQ", :triage_team_name => "my-triage-team")
         end
 
@@ -132,6 +125,24 @@ RSpec.describe GithubService::Commands::RemoveLabel do
           expect(issue).to receive(:remove_label).with("jansa/no")
           expect(issue).to receive(:remove_label).with("jansa/yes")
           expect(issue).to receive(:remove_label).with("jansa/yes?")
+        end
+      end
+
+      context "with string and regex patterns in unremovable labels" do
+        let(:command_value) { "wontfix, jansa/no, test/foo" }
+
+        before do
+          message = "@chessbyte Cannot remove the following labels since they require " \
+                    "[triage team permissions](https://github.com/orgs/ManageIQ/teams/core-triage)" \
+                    ": jansa/no, test/foo"
+
+          expect(issue).to receive(:add_comment).with(message)
+        end
+
+        it "treats exact strings and regexps as unremovable" do
+          expect(issue).to     receive(:remove_label).with("wontfix")
+          expect(issue).not_to receive(:remove_label).with("jansa/no")
+          expect(issue).not_to receive(:remove_label).with("test/foo")
         end
       end
     end


### PR DESCRIPTION
@bdunne Please review.

This PR adds regex support to the unremovable and unassignable sections. This way, in prod, _anything_ ending in `/yes`, `/backported`, `/no` is unremovable and _anything_ ending in `/yes?` is unassignable (without permissions)

This allows me to never have to update this ever again 😆 
