### PR TITLE
Change DiffContentChecker to be case insensitive by default

### DIFF
--- a/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/diff_content_checker.rb
+++ b/app/workers/commit_monitor_handlers/commit_range/github_pr_commenter/diff_content_checker.rb
@@ -40,8 +40,8 @@ module CommitMonitorHandlers::CommitRange
       Settings.diff_content_checker.offenses.each do |offender, options|
         next if options.except.try(:any?) { |except| file_path.start_with?(except) }
 
-        regexp = options.type == :regexp ? Regexp.new(offender.to_s) : /\b#{Regexp.escape(offender.to_s)}\b/i
-        add_offense(offender, options, file_path, line) if regexp.match(line.content)
+        regexp = options.type == :regexp ? Regexp.new(offender.to_s, Regexp::IGNORECASE) : /\b#{Regexp.escape(offender.to_s)}\b/i
+        add_offense(offender, options, file_path, line) if regexp.match?(line.content)
       end
     end
 

--- a/spec/workers/commit_monitor_handlers/commit_range/github_pr_commenter/diff_content_checker_spec.rb
+++ b/spec/workers/commit_monitor_handlers/commit_range/github_pr_commenter/diff_content_checker_spec.rb
@@ -79,4 +79,49 @@ describe CommitMonitorHandlers::CommitRange::GithubPrCommenter::DiffContentCheck
       )
     end
   end
+
+  context "with case-insensitive matching" do
+    context "for string type" do
+      let(:content_1) { "def a(variable)" }
+      let(:content_2) { "PUTS 'hi'" }
+      let(:content_3) { "Puts 'hello'" }
+
+      it "matches case-insensitively" do
+        stub_settings(:diff_content_checker => {"offenses" => {"puts" => {:severity => :error}}})
+        described_class.new.perform(batch_entry.id, branch.id, nil, nil)
+
+        batch_entry.reload
+        expect(batch_entry.result.length).to eq(2)
+        expect(batch_entry.result.first).to have_attributes(
+          :group   => file_path,
+          :locator => 2,
+          :message => "Detected `puts`"
+        )
+        expect(batch_entry.result.last).to have_attributes(
+          :group   => file_path,
+          :locator => 3,
+          :message => "Detected `puts`"
+        )
+      end
+    end
+
+    context "for regexp type" do
+      let(:content_1) { "def a(variable)" }
+      let(:content_2) { "# PUTS 'hi'" }
+      let(:content_3) { "Puts 'hello'" }
+
+      it "matches case-insensitively" do
+        stub_settings(:diff_content_checker => {"offenses" => {"^([^#]+|)\\bputs\\b" => {:severity => :error, :type => :regexp, :message => "Detected `puts`"}}})
+        described_class.new.perform(batch_entry.id, branch.id, nil, nil)
+
+        batch_entry.reload
+        expect(batch_entry.result.length).to eq(1)
+        expect(batch_entry.result.first).to have_attributes(
+          :group   => file_path,
+          :locator => 3,
+          :message => "Detected `puts`"
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
~~Adds case_sensitive option to control pattern matching behavior. Defaults to true (case-sensitive). Works with both string and regexp types. Extracts regexp building into build_regexp method.~~

This changes the DiffContentChecker to ensure strings are case insensitive by default. We found a few cases where strings were being checked in a case sensitive way, when we expected case insensitive.

@bdunne Please review.