### PR TITLE
Bump websocket-driver to v0.8.2 for CVE-2026-61666

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,7 +385,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
#955 #956 #957 #959 

@bdunne Please review