### PR TITLE
Recognize WIP after other title tags

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -84,7 +84,7 @@ class Branch < ActiveRecord::Base
   end
 
   def pr_title_tags
-    pr_title.to_s.match(/^(?:\s*\[[\w-]+\])+/).to_s.gsub("[", " [").split.map { |s| s[1...-1] }
+    GithubService.title_tags(pr_title)
   end
 
   def github_pr_uri

--- a/lib/github_service.rb
+++ b/lib/github_service.rb
@@ -1,4 +1,6 @@
 module GithubService
+  TITLE_TAGS_REGEX = /^(?:\s*\[[\w-]+\])+/
+
   ##
   # GithubService is miq-bot's interface to the Github API. It acts as a
   # wrapper around Octokit, delegating calls directly to the Octokit client as
@@ -47,7 +49,7 @@ module GithubService
     alias issues list_issues
 
     def title_tags(title)
-      title.to_s.match(/^(?:\s*\[[\w-]+\])+/).to_s.scan(/\[([\w-]+)\]/).flatten
+      title.to_s.match(TITLE_TAGS_REGEX).to_s.scan(/\[([\w-]+)\]/).flatten
     end
 
     def search_issues(*args)

--- a/lib/github_service.rb
+++ b/lib/github_service.rb
@@ -46,6 +46,10 @@ module GithubService
     end
     alias issues list_issues
 
+    def title_tags(title)
+      title.to_s.match(/^(?:\s*\[[\w-]+\])+/).to_s.scan(/\[([\w-]+)\]/).flatten
+    end
+
     def search_issues(*args)
       service.search_issues(*args).items.map { |issue| Issue.new(issue) }
     end

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -6,7 +6,6 @@ module GithubService
 
     STALE_LABEL       = 'stale'.freeze
     UNMERGEABLE_LABEL = 'unmergeable'.freeze
-    WIP_REGEX         = /^(?:\s*\[wip\])+/i
 
     def assign(user)
       GithubService.update_issue(fq_repo_name, number, "assignee" => user)
@@ -118,15 +117,20 @@ module GithubService
     private
 
     def wipify_title
-      if title !~ WIP_REGEX
-        update(:title => "[WIP] #{title}")
-      end
+      update(:title => "[WIP] #{title}") unless wip_title_tag?
     end
 
     def unwipify_title
-      if (match = title.match(WIP_REGEX))
-        update(:title => match.post_match.lstrip)
-      end
+      tags = GithubService.title_tags(title)
+      return unless tags.any? { |tag| tag.casecmp?("wip") }
+
+      title_without_tags = title.sub(/^(?:\s*\[[\w-]+\])+/, "").lstrip
+      tags.reject! { |tag| tag.casecmp?("wip") }
+      update(:title => [tags.map { |tag| "[#{tag}]" }.join(" "), title_without_tags].reject(&:empty?).join(" "))
+    end
+
+    def wip_title_tag?
+      GithubService.title_tags(title).any? { |tag| tag.casecmp?("wip") }
     end
 
     def update(options)

--- a/lib/github_service/issue.rb
+++ b/lib/github_service/issue.rb
@@ -124,7 +124,7 @@ module GithubService
       tags = GithubService.title_tags(title)
       return unless tags.any? { |tag| tag.casecmp?("wip") }
 
-      title_without_tags = title.sub(/^(?:\s*\[[\w-]+\])+/, "").lstrip
+      title_without_tags = title.sub(GithubService::TITLE_TAGS_REGEX, "").lstrip
       tags.reject! { |tag| tag.casecmp?("wip") }
       update(:title => [tags.map { |tag| "[#{tag}]" }.join(" "), title_without_tags].reject(&:empty?).join(" "))
     end

--- a/spec/lib/github_service/issue_spec.rb
+++ b/spec/lib/github_service/issue_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe GithubService::Issue do
+  subject(:issue) { described_class.new(source_issue) }
+
+  let(:fq_repo_name) { "foo/bar" }
+  let(:issue_number) { 123 }
+  let(:labels) { [] }
+  let(:source_issue) do
+    double(
+      "issue",
+      :labels         => labels.map { |label| double(:name => label) },
+      :number         => issue_number,
+      :repository_url => "https://api.github.com/repos/#{fq_repo_name}",
+      :title          => title
+    )
+  end
+  let(:github_client) { double }
+
+  before do
+    allow(GithubService).to receive(:service).and_return(github_client)
+  end
+
+  describe "#add_label" do
+    before do
+      allow(github_client).to receive(:add_labels_to_an_issue)
+    end
+
+    context "when WIP follows another title tag" do
+      let(:title) { "[RFR] [WIP] Fix title" }
+
+      it "does not add another WIP title tag" do
+        expect(GithubService).not_to receive(:update_issue)
+
+        issue.add_label("wip")
+
+        expect(github_client).to have_received(:add_labels_to_an_issue).with(fq_repo_name, issue_number, ["wip"])
+      end
+    end
+  end
+
+  describe "#remove_label" do
+    let(:labels) { ["wip"] }
+
+    before do
+      allow(github_client).to receive(:remove_label)
+    end
+
+    context "when WIP follows another title tag" do
+      let(:title) { "[RFR] [WIP] Fix title" }
+
+      it "removes only the WIP title tag" do
+        expect(GithubService).to receive(:update_issue)
+          .with(fq_repo_name, issue_number, {:title => "[RFR] Fix title"})
+
+        issue.remove_label("wip")
+
+        expect(github_client).to have_received(:remove_label).with(fq_repo_name, issue_number, "wip")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uses the existing leading title-tag parser when adding or removing the `wip` label. This recognizes `WIP` after tags such as `RFR`, avoids adding a duplicate `[WIP]`, and preserves other leading tags when WIP is removed.

The regression spec fails on `master`: adding the label changes `[RFR] [WIP] Fix title` to `[WIP] [RFR] [WIP] Fix title`, while removing the label leaves the title unchanged.

Fixes #334

Tested:

- `bundle exec rspec spec/lib/github_service/issue_spec.rb spec/models/branch_spec.rb spec/workers/pull_request_monitor_handlers/wip_labeler_spec.rb` (`37 examples, 0 failures`)
- `bundle exec rake` (`365 examples, 0 failures` on Ruby 3.3.10/Linux)
