### PR TITLE
Skip linters when changed files were deleted

### DIFF
--- a/lib/linter/base.rb
+++ b/lib/linter/base.rb
@@ -22,12 +22,19 @@ module Linter
           logger.error("#{log_header} Failed to run due to missing config files.")
           return failed_linter_offenses("missing config files")
         else
-          files += collected_files_to_lint(dir)
+          target_files = collected_files_to_lint(dir)
+          if target_files.empty?
+            logger.info("#{log_header} Skipping run due to no extractable files.")
+            next
+          end
+
+          files += target_files
           logger.info("#{log_header} Collected #{files.length} files.")
           logger.debug { "#{log_header} File list: #{files.inspect}" }
           run_linter(dir)
         end
       end
+      return if result.nil?
 
       offenses = parse_output(result.output)
       logger.info("#{log_header} Completed run with #{offenses.fetch_path('summary', 'offense_count')} offenses")

--- a/spec/lib/linter/base_spec.rb
+++ b/spec/lib/linter/base_spec.rb
@@ -1,5 +1,24 @@
 RSpec.describe Linter::Base do
-  subject { described_class.new(double("branch")) }
+  subject { described_class.new(branch) }
+
+  let(:branch) { double("branch", :logger => logger, :name => "pr/1", :repo => double(:name => "foo/bar")) }
+  let(:logger) { double("logger", :debug => nil, :info => nil) }
+
+  describe "#run" do
+    context "when the only candidate file was deleted" do
+      before do
+        allow(subject).to receive(:files_to_lint).and_return(["deleted.haml"])
+        allow(subject).to receive(:collected_config_files).and_return([".haml-lint.yml"])
+        allow(subject).to receive(:collected_files_to_lint).and_return([])
+      end
+
+      it "does not run the linter" do
+        expect(subject).not_to receive(:run_linter)
+
+        expect(subject.run).to be_nil
+      end
+    end
+  end
 
   describe "#linter_env" do
     it "is an empty hash" do


### PR DESCRIPTION
Deleted files remain in the diff candidate list, but cannot be extracted into the temporary lint directory. When the only matching file is deleted, the linter runs against configuration files alone and reports `error parsing JSON result`.

Skip the linter when no target files were extracted. Missing configuration still reports an error.

Before (regression spec applied to `master`):

- `bundle exec rspec spec/lib/linter/base_spec.rb` (`2 examples, 1 failure`)
- Expected `run_linter` not to be called, but it was called once.

After:

- `bundle exec rspec spec/lib/linter/base_spec.rb spec/lib/linter/haml_spec.rb spec/lib/linter/rubocop_spec.rb spec/lib/linter/yaml_spec.rb spec/workers/concerns/code_analysis_mixin_spec.rb` (`11 examples, 0 failures`)
- `bundle exec rake` (`364 examples, 0 failures`)
- `bundle exec rubocop lib/linter/base.rb spec/lib/linter/base_spec.rb` (no offenses)

Fixes #602

@miq-bot add-label bug
@miq-bot add-reviewer @Fryguy